### PR TITLE
docs: document MCP SSE endpoint and add rule to keep README in sync

### DIFF
--- a/.cursor/rules/update-readme.mdc
+++ b/.cursor/rules/update-readme.mdc
@@ -1,0 +1,14 @@
+---
+description: Always update README and docs when adding or changing features
+alwaysApply: true
+---
+
+# Keep docs in sync with code
+
+When you add or change functionality (new endpoints, MCP behavior, env vars, architecture):
+
+1. **Update the README** if the change is user-facing: new or changed endpoints, environment variables, quick start, or architecture diagram. Add a short "MCP / SSE endpoint"–style section if you introduce a new way to use the server.
+2. **Update `docs/architecture.md`** when you change how the app is structured, add new transports (e.g. SSE), or change data flow.
+3. **Update `DESIGN_SPEC.md`** or **CONTRIBUTING.md** when you change how contributors add providers or tools.
+
+Before finishing a feature or PR, confirm that README and any relevant architecture/contributing docs reflect the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ The global registry in `bigas/registry.py`:
 - Instantiates only those where `is_configured()` returns `True`
 - Exposes active providers via `GET /mcp/providers`
 
+New tools you add via `@register_tool` appear in `GET /mcp/manifest` and are also available via the MCP JSON-RPC endpoint `POST /mcp` (methods `tools/list` and `tools/call`); no extra wiring is needed.
+
 ### Example: QuickBooks finance provider
 
 To add QuickBooks as a finance provider (see `DESIGN_SPEC.md` for the full example):

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-bigas is a Flask-based MCP server (`app.py`) with three resource blueprints:
+bigas is a Flask-based MCP server (`app.py`) with three resource blueprints. The server exposes tools in two ways: (1) **HTTP** at `/mcp/tools/*` and `GET /mcp/manifest` for curl and Cloud Scheduler, and (2) **MCP over SSE** at `GET/POST /mcp` for JSON-RPC (initialize, tools/list, tools/call), used by MCP clients such as Claude and Cursor. New tools registered with `@register_tool` appear in both; no changes to the `/mcp` handler are required when adding providers.
 - `bigas/resources/marketing/` — GA4 analytics + ad platforms (LinkedIn, Reddit, Google Ads, Meta)
 - `bigas/resources/product/` — Jira release notes + progress updates
 - `bigas/resources/cto/` — GitHub PR review

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Per-feature model overrides: `BIGAS_MARKETING_LLM_MODEL`, `BIGAS_RELEASE_NOTES_M
 MCP clients (Claude, Cursor, etc.) can connect using the standard MCP-over-SSE transport:
 
 - **GET /mcp** — Opens a long-lived Server-Sent Events stream. The server sends an initial `server/ready` event and keep-alive comments so the client maintains the connection.
-- **POST /mcp** — Accepts MCP JSON-RPC requests: `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`. Tool calls are routed internally to the corresponding `/mcp/tools/*` endpoints.
+- **POST /mcp** — Accepts MCP JSON-RPC requests: `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`.
 
-Tools are the same as in the HTTP API; they are listed via `tools/list` and invoked via `tools/call`. When using restricted access (`BIGAS_ACCESS_MODE=restricted`), send your access key in the configured header (e.g. `X-Bigas-Access-Key`) or as `Authorization: Bearer <key>` on POST requests to `/mcp`.
+Tools are the same as in the HTTP API; they are listed via `tools/list` and invoked via `tools/call`. The initial GET /mcp connection is unauthenticated. When using restricted access (`BIGAS_ACCESS_MODE=restricted`), you must send your access key in the configured header (e.g. `X-Bigas-Access-Key`) or as `Authorization: Bearer <key>` on subsequent POST requests to `/mcp`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Follow us on X: **[@bigasmyaiteam](https://x.com/bigasmyaiteam)**
 
 ## What is Bigas?
 
-**Bigas** (Latin for *team*) is an MCP server that gives solo founders a team of virtual specialists across **marketing, product, and engineering**. It is **opinionated** toward Google Cloud (Cloud Run, GA4, GCS, Cloud Scheduler), Discord, and Jira/GitHub so you can get going quickly with minimal config. The stack is **modular and provider-based**: you can plug in new data sources and capabilities (for example finance and support), and run the Flask app on other clouds or on-premises if you prefer. Active providers are discoverable via `GET /mcp/providers` (see `CONTRIBUTING.md` and `docs/architecture.md`). It connects to your data sources and delivers AI-powered insights to Discord — or can be triggered directly from any MCP client (Claude, Cursor, etc.) or automated via Cloud Scheduler.
+**Bigas** (Latin for *team*) is an MCP server that gives solo founders a team of virtual specialists across **marketing, product, and engineering**. It is **opinionated** toward Google Cloud (Cloud Run, GA4, GCS, Cloud Scheduler), Discord, and Jira/GitHub so you can get going quickly with minimal config. The stack is **modular and provider-based**: you can plug in new data sources and capabilities (for example finance and support), and run the Flask app on other clouds or on-premises if you prefer. Active providers are discoverable via `GET /mcp/providers` (see `CONTRIBUTING.md` and `docs/architecture.md`). It connects to your data sources and delivers AI-powered insights to Discord — or can be triggered directly from any MCP client (Claude, Cursor, etc.) or automated via Cloud Scheduler. The server exposes an **SSE-based MCP endpoint** at `GET/POST /mcp` for JSON-RPC (initialize, tools/list, tools/call), so clients connect via the standard MCP transport.
 
 It currently includes three specialists:
 
@@ -105,6 +105,17 @@ Per-feature model overrides: `BIGAS_MARKETING_LLM_MODEL`, `BIGAS_RELEASE_NOTES_M
 3. Copy your **Property ID** (Admin → Property Details) into `GA4_PROPERTY_ID`
 
 > If you get a 403 error, wait a few minutes for permissions to propagate.
+
+---
+
+## MCP / SSE endpoint
+
+MCP clients (Claude, Cursor, etc.) can connect using the standard MCP-over-SSE transport:
+
+- **GET /mcp** — Opens a long-lived Server-Sent Events stream. The server sends an initial `server/ready` event and keep-alive comments so the client maintains the connection.
+- **POST /mcp** — Accepts MCP JSON-RPC requests: `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`. Tool calls are routed internally to the corresponding `/mcp/tools/*` endpoints.
+
+Tools are the same as in the HTTP API; they are listed via `tools/list` and invoked via `tools/call`. When using restricted access (`BIGAS_ACCESS_MODE=restricted`), send your access key in the configured header (e.g. `X-Bigas-Access-Key`) or as `Authorization: Bearer <key>` on POST requests to `/mcp`.
 
 ---
 
@@ -227,13 +238,13 @@ All jobs use **HTTP POST** to your Cloud Run service URL.
 ```
                     ┌─────────────────────────────────────────┐
                     │            Clients / Triggers            │
-                    │  MCP Client · Cloud Scheduler · curl     │
+                    │  MCP Client (SSE+JSON-RPC) · Scheduler · curl │
                     └─────────────────────────────────────────┘
                                          │
                                          ▼
                     ┌─────────────────────────────────────────┐
                     │      Flask app (e.g. Cloud Run)          │
-                    │  /mcp/tools/*  — MCP endpoint router     │
+                    │  /mcp — SSE + JSON-RPC; /mcp/tools/* — HTTP │
                     └────────────────┬────────────────────────┘
                     ┌───────────────┼────────────────────────┐
                     ▼               ▼                        ▼


### PR DESCRIPTION
- README: add MCP/SSE section, update What is Bigas and architecture diagram
- docs/architecture.md: MCP bridge and SSE transport section, update diagram
- DESIGN_SPEC.md, CONTRIBUTING.md: note tools exposed via /mcp JSON-RPC
- .cursor/rules: always-update-readme rule when adding/changing features