### PR TITLE
fix: Discord notification provider import and env check

### DIFF
--- a/bigas/providers/notifications/discord.py
+++ b/bigas/providers/notifications/discord.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional
 
 from bigas.providers.notifications.base import NotificationChannel
-from bigas.resources.marketing.template_service import send_discord_message
+from bigas.resources.marketing.endpoints import send_discord_message
 
 
 class DiscordNotificationChannel(NotificationChannel):
@@ -12,7 +12,9 @@ class DiscordNotificationChannel(NotificationChannel):
     def is_configured(cls) -> bool:
         # The existing Discord integration relies on DISCORD_WEBHOOK_URL (or similar)
         # being present. We treat any non-empty webhook env var as configured.
-        return bool(os.getenv("DISCORD_WEBHOOK_URL"))
+        return bool(
+            os.getenv("DISCORD_WEBHOOK_URL_MARKETING") or os.getenv("DISCORD_WEBHOOK_URL")
+        )
 
     def send(self, message: str, channel_hint: Optional[str] = None) -> bool:
         """

--- a/bigas/providers/notifications/discord.py
+++ b/bigas/providers/notifications/discord.py
@@ -1,8 +1,10 @@
-import os
 from typing import Optional
 
 from bigas.providers.notifications.base import NotificationChannel
-from bigas.resources.marketing.endpoints import send_discord_message
+from bigas.resources.marketing.endpoints import (
+    _get_discord_webhook_url,
+    send_discord_message,
+)
 
 
 class DiscordNotificationChannel(NotificationChannel):
@@ -10,20 +12,16 @@ class DiscordNotificationChannel(NotificationChannel):
 
     @classmethod
     def is_configured(cls) -> bool:
-        # The existing Discord integration relies on DISCORD_WEBHOOK_URL (or similar)
-        # being present. We treat any non-empty webhook env var as configured.
-        return bool(
-            os.getenv("DISCORD_WEBHOOK_URL_MARKETING") or os.getenv("DISCORD_WEBHOOK_URL")
-        )
+        return bool(_get_discord_webhook_url())
 
     def send(self, message: str, channel_hint: Optional[str] = None) -> bool:
         """
         Delegate to the existing Discord helper. channel_hint may be ignored or
         used by the underlying implementation if supported.
+        Returns True only if the message was successfully delivered.
         """
         try:
-            send_discord_message(message)
-            return True
+            return send_discord_message(message)
         except Exception:
             return False
 

--- a/bigas/resources/marketing/endpoints.py
+++ b/bigas/resources/marketing/endpoints.py
@@ -6351,32 +6351,44 @@ def cleanup_old_reports():
         return jsonify({"error": str(e)}), 500
 
 
+def _get_discord_webhook_url() -> str | None:
+    """
+    Return the Discord webhook URL to use (DISCORD_WEBHOOK_URL_MARKETING or DISCORD_WEBHOOK_URL).
+    Returns None if unset, empty, or placeholder. Shared by send_discord_message and the Discord notification provider.
+    """
+    url = os.environ.get("DISCORD_WEBHOOK_URL_MARKETING") or os.environ.get("DISCORD_WEBHOOK_URL")
+    if not url or not url.strip():
+        return None
+    if url.strip().lower().startswith("placeholder"):
+        return None
+    return url.strip()
+
+
 def send_discord_message(message: str) -> bool:
     """
-    Post a single message to the default Discord webhook (DISCORD_WEBHOOK_URL_MARKETING or DISCORD_WEBHOOK_URL).
-    Used by the notifications provider. Returns True if a webhook was configured and the post succeeded (or was skipped due to placeholder).
+    Post a single message to the default Discord webhook. Used by the notifications provider.
+    Returns True only if the message was successfully delivered (HTTP 204).
     """
-    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL_MARKETING") or os.environ.get("DISCORD_WEBHOOK_URL")
-    if not webhook_url or not webhook_url.strip():
+    webhook_url = _get_discord_webhook_url()
+    if not webhook_url:
         return False
-    post_to_discord(webhook_url, message)
-    return True
+    return post_to_discord(webhook_url, message)
 
 
-def post_to_discord(webhook_url, message: str):
+def post_to_discord(webhook_url, message: str) -> bool:
     """
     Post a single message to Discord, truncating hard at 2000 characters.
+    Returns True if the request succeeded (HTTP 204), False otherwise.
 
     NOTE: For longer, multi-part messages use post_long_to_discord instead.
     """
-    # Skip Discord posting if webhook URL is empty, not provided, or placeholder
     if (
         not webhook_url
         or webhook_url.strip() == ""
         or webhook_url.strip().lower().startswith("placeholder")
     ):
         logger.info("Discord webhook URL not provided or is placeholder, skipping Discord notification")
-        return
+        return False
 
     if len(message) > 2000:
         message = message[:1997] + "..."
@@ -6389,10 +6401,12 @@ def post_to_discord(webhook_url, message: str):
         )
         if response.status_code != 204:
             logger.error(f"Failed to post to Discord: {response.status_code}, {response.text}")
-        else:
-            logger.info("Successfully posted to Discord")
+            return False
+        logger.info("Successfully posted to Discord")
+        return True
     except Exception as e:
         logger.error(f"Error posting to Discord: {e}")
+        return False
 
 
 def post_long_to_discord(webhook_url: str, text: str, chunk_size: int = 1900):

--- a/bigas/resources/marketing/endpoints.py
+++ b/bigas/resources/marketing/endpoints.py
@@ -6351,6 +6351,18 @@ def cleanup_old_reports():
         return jsonify({"error": str(e)}), 500
 
 
+def send_discord_message(message: str) -> bool:
+    """
+    Post a single message to the default Discord webhook (DISCORD_WEBHOOK_URL_MARKETING or DISCORD_WEBHOOK_URL).
+    Used by the notifications provider. Returns True if a webhook was configured and the post succeeded (or was skipped due to placeholder).
+    """
+    webhook_url = os.environ.get("DISCORD_WEBHOOK_URL_MARKETING") or os.environ.get("DISCORD_WEBHOOK_URL")
+    if not webhook_url or not webhook_url.strip():
+        return False
+    post_to_discord(webhook_url, message)
+    return True
+
+
 def post_to_discord(webhook_url, message: str):
     """
     Post a single message to Discord, truncating hard at 2000 characters.


### PR DESCRIPTION
- Add send_discord_message() in endpoints.py (uses DISCORD_WEBHOOK_URL_MARKETING or DISCORD_WEBHOOK_URL)
- Discord provider imports from endpoints instead of template_service
- is_configured() checks both webhook env vars