### PR TITLE
Fix autofix stuck on confirmation prompts

### DIFF
--- a/bigas/resources/cto/autofix/service.py
+++ b/bigas/resources/cto/autofix/service.py
@@ -44,7 +44,25 @@ Pull request: {pr_url}
 5. Every commit message you create MUST include the exact marker `{AUTOFIX_COMMIT_MARKER}`.
 6. Do not merge the PR, do not force-push, do not rewrite history, and do not open a new PR.
 7. If after inspecting the code there is nothing safe to fix, make no commits and explain why.
+8. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — apply the fixes and push commits immediately. Do not stop after a proposal.
 """
+
+
+def autofix_looks_like_confirmation_stop(result_text: str) -> bool:
+    """True when Cursor run result suggests it stopped to ask for confirmation."""
+    text = (result_text or "").lower()
+    if not text:
+        return False
+    needles = (
+        "shall i proceed",
+        "please confirm",
+        "confirm before",
+        "before i proceed",
+        "want me to proceed",
+        "should i proceed",
+        "do you want me to",
+    )
+    return any(n in text for n in needles)
 
 
 class AutofixService:
@@ -164,6 +182,18 @@ class AutofixService:
         try:
             return client.get_run_status(agent_id=agent_id, run_id=run_id)
         except CursorCloudAgentError as e:
+            raise AutofixError(str(e)) from e
+
+    def get_pr_head_commit(
+        self, *, repo: str, pr_number: int
+    ) -> tuple[str, str]:
+        owner, repo_name = repo.split("/", 1)
+        gh = GitHubPRCommentClient(token=self._github_token)
+        try:
+            return gh.get_pr_head_commit(
+                owner=owner, repo=repo_name, pr_number=pr_number
+            )
+        except GitHubPRCommentError as e:
             raise AutofixError(str(e)) from e
 
     def fetch_pr_diff(self, *, repo: str, pr_number: int) -> str:

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -9,8 +9,15 @@ import os
 import requests
 from flask import Blueprint, jsonify, request
 
-from bigas.resources.cto.autofix.heuristics import review_is_ready_to_merge
-from bigas.resources.cto.autofix.service import AutofixError, AutofixService
+from bigas.resources.cto.autofix.heuristics import (
+    latest_commit_is_autofix,
+    review_is_ready_to_merge,
+)
+from bigas.resources.cto.autofix.service import (
+    AutofixError,
+    AutofixService,
+    autofix_looks_like_confirmation_stop,
+)
 from bigas.resources.cto.pr_review.github_client import (
     BIGAS_REVIEW_MARKER,
     GitHubPRCommentClient,
@@ -368,7 +375,42 @@ def autofix_followup():
             f"**CTO autofix failed**\nPR: {pr_url}\n"
             f"Status: {run_status}\nAgent: {agent_url}"
         )
-        base.update({"finalized": True, "ready_to_merge": False})
+        base.update({"finalized": True, "ready_to_merge": False, "fixes_pushed": False})
+        return jsonify(base)
+
+    fixes_pushed = False
+    head_sha = ""
+    try:
+        head_sha, head_message = service.get_pr_head_commit(
+            repo=repo, pr_number=pr_number
+        )
+        fixes_pushed = latest_commit_is_autofix(head_message)
+    except AutofixError as e:
+        logger.warning("Could not read PR head after autofix: %s", e)
+
+    result_text = status.get("result_text") or ""
+    asked_confirm = autofix_looks_like_confirmation_stop(result_text)
+    if not fixes_pushed:
+        why = (
+            "Agent appears to have stopped to ask for confirmation."
+            if asked_confirm
+            else "No `[bigas-autofix]` commit on PR head (nothing pushed, or agent only proposed changes)."
+        )
+        _post_to_discord_cto(
+            f"**CTO autofix finished without commits**\nPR: {pr_url}\n"
+            f"{why}\nAgent: {agent_url}\n"
+            f"Re-run autofix or continue the agent manually."
+        )
+        base.update(
+            {
+                "finalized": True,
+                "ready_to_merge": False,
+                "fixes_pushed": False,
+                "asked_confirmation": asked_confirm,
+                "head_sha": head_sha,
+                "rereviewed": False,
+            }
+        )
         return jsonify(base)
 
     _post_to_discord_cto(
@@ -455,6 +497,7 @@ def autofix_followup():
         "rereviewed": True,
         "comment_url": comment_url,
         "ready_to_merge": ready,
+        "fixes_pushed": True,
         "used_model": review_service._model,
         "jira_final_approval": jira_final,
     })

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -72,6 +72,9 @@ Polled by GitHub Actions after launch:
 
 - Not done yet: `{ "done": false, "status": "RUNNING", ... }`
 - Done + re-reviewed: `{ "done": true, "ok": true, "rereviewed": true, "ready_to_merge": true, "comment_url": "..." }`
+- Done but no `[bigas-autofix]` commit (e.g. agent asked for confirmation): Discord warning, `{ "fixes_pushed": false, "rereviewed": false }` — no fake “completed” message
+
+The autofix prompt instructs the agent **not** to ask for confirmation and to push fixes immediately.
 
 ## Guards
 

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -2,6 +2,10 @@ from bigas.resources.cto.autofix.heuristics import (
     latest_commit_is_autofix,
     review_needs_autofix,
 )
+from bigas.resources.cto.autofix.service import (
+    _build_prompt,
+    autofix_looks_like_confirmation_stop,
+)
 
 
 def test_lgtm_skips():
@@ -36,3 +40,23 @@ def test_important_runs():
 def test_autofix_commit_marker():
     assert latest_commit_is_autofix("fix: auth [bigas-autofix]")
     assert not latest_commit_is_autofix("fix: auth")
+
+
+def test_autofix_prompt_forbids_confirmation():
+    prompt = _build_prompt(
+        repo="mckort/bigas",
+        pr_number=1,
+        pr_url="https://github.com/mckort/bigas/pull/1",
+        review_body="## Blocking\nFix auth",
+    )
+    assert "Do NOT ask for confirmation" in prompt
+    assert "apply the fixes and push commits immediately" in prompt
+
+
+def test_autofix_looks_like_confirmation_stop():
+    assert autofix_looks_like_confirmation_stop(
+        "Proposed changes...\n\nShall I proceed with implementing these?"
+    )
+    assert autofix_looks_like_confirmation_stop("Please confirm before I proceed.")
+    assert not autofix_looks_like_confirmation_stop("Pushed [bigas-autofix] commits.")
+    assert not autofix_looks_like_confirmation_stop("")


### PR DESCRIPTION
## Summary
- Autofix prompt forbids asking for confirmation — push fixes immediately.
- `autofix_followup` checks for a `[bigas-autofix]` head commit; if missing, Discord warns (incl. confirmation-language detection) and skips fake “completed” + re-review.

## Test plan
- [x] `pytest tests/test_autofix_heuristics.py`
- [ ] Deploy Cloud Run
- [ ] Trigger autofix on a PR with findings; agent should not ask to proceed