### PR TITLE
Autofix iteration loop + Final approval on LGTM

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -77,77 +77,27 @@ jobs:
           echo "Bigas returned 200 OK."
           cat response_body.txt || true
 
-      - name: Trigger Bigas autofix (optional)
+      - name: Autofix loop (up to 3 rounds) + re-review
         if: ${{ vars.BIGAS_AUTO_FIX == 'true' }}
-        id: autofix
-        env:
-          BIGAS_URL: ${{ vars.BIGAS_URL }}
-          BIGAS_API_KEY: ${{ secrets.BIGAS_API_KEY }}
-        run: |
-          python3 -c "
-          import json, os
-          payload = {
-              'repo': os.environ['GITHUB_REPOSITORY'],
-              'pr_number': ${{ github.event.pull_request.number }},
-          }
-          with open('autofix_payload.json', 'w') as f:
-              json.dump(payload, f)
-          "
-          HTTP_CODE=$(curl -sS -w "%{http_code}" -o autofix_response.txt -X POST "$BIGAS_URL/mcp/tools/autofix_pr" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $BIGAS_API_KEY" \
-            -d @autofix_payload.json)
-          echo "http_code=$HTTP_CODE" >> $GITHUB_OUTPUT
-          echo "Autofix HTTP $HTTP_CODE"
-          cat autofix_response.txt || true
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Bigas autofix returned HTTP $HTTP_CODE"
-            exit 1
-          fi
-          python3 -c "
-          import json
-          data = json.load(open('autofix_response.txt'))
-          launched = 'true' if data.get('launched') else 'false'
-          open('autofix_launched.txt','w').write(launched)
-          open('autofix_agent_id.txt','w').write(data.get('agent_id') or '')
-          open('autofix_run_id.txt','w').write(data.get('run_id') or '')
-          print('launched=', launched)
-          print('agent_id=', data.get('agent_id') or '')
-          "
-          echo "launched=$(cat autofix_launched.txt)" >> $GITHUB_OUTPUT
-
-      - name: Wait for autofix + re-review
-        if: ${{ vars.BIGAS_AUTO_FIX == 'true' && steps.autofix.outputs.launched == 'true' }}
         env:
           BIGAS_URL: ${{ vars.BIGAS_URL }}
           BIGAS_API_KEY: ${{ secrets.BIGAS_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          MAX_AUTOFIX_ROUNDS: "3"
         run: |
-          AGENT_ID=$(cat autofix_agent_id.txt)
-          if [ -z "$AGENT_ID" ]; then
-            echo "::error::autofix launched but agent_id missing"
-            exit 1
-          fi
           python3 <<'PY'
           import json, os, time, urllib.error, urllib.request
 
           base = os.environ["BIGAS_URL"].rstrip("/")
           api_key = os.environ["BIGAS_API_KEY"]
-          agent_id = open("autofix_agent_id.txt").read().strip()
-          run_id = open("autofix_run_id.txt").read().strip()
-          payload = {
-              "repo": os.environ["GITHUB_REPOSITORY"],
-              "pr_number": int(os.environ["PR_NUMBER"]),
-              "agent_id": agent_id,
-              "finalize": False,
-          }
-          if run_id:
-              payload["run_id"] = run_id
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = int(os.environ["PR_NUMBER"])
+          max_rounds = int(os.environ.get("MAX_AUTOFIX_ROUNDS") or "3")
 
-          def call(body_obj, timeout=180):
+          def call(path, body_obj, timeout=180):
               data = json.dumps(body_obj).encode()
               req = urllib.request.Request(
-                  f"{base}/mcp/tools/autofix_followup",
+                  f"{base}/mcp/tools/{path}",
                   data=data,
                   headers={
                       "Content-Type": "application/json",
@@ -166,35 +116,87 @@ jobs:
                       parsed = {"error": raw[:500]}
                   return e.code, parsed
 
-          # Poll status only (no Discord) until terminal — ~30 min.
-          attempts = 60
-          sleep_s = 30
-          last = None
-          for i in range(1, attempts + 1):
-              code, last = call(payload)
-              print(
-                  f"poll {i}/{attempts}: HTTP {code} done={last.get('done')} "
-                  f"status={last.get('status')}"
-              )
-              if code >= 500:
+          def wait_and_finalize(agent_id, run_id):
+              payload = {
+                  "repo": repo,
+                  "pr_number": pr_number,
+                  "agent_id": agent_id,
+                  "finalize": False,
+              }
+              if run_id:
+                  payload["run_id"] = run_id
+              attempts = 60
+              sleep_s = 30
+              last = None
+              for i in range(1, attempts + 1):
+                  code, last = call("autofix_followup", payload)
+                  print(
+                      f"poll {i}/{attempts}: HTTP {code} done={last.get('done')} "
+                      f"status={last.get('status')}"
+                  )
+                  if code >= 500:
+                      time.sleep(sleep_s)
+                      continue
+                  if code != 200:
+                      raise SystemExit(
+                          f"autofix_followup poll failed: HTTP {code} {last}"
+                      )
+                  if last.get("done"):
+                      break
                   time.sleep(sleep_s)
-                  continue
-              if code != 200:
-                  raise SystemExit(f"autofix_followup poll failed: HTTP {code} {last}")
-              if last.get("done"):
-                  break
-              time.sleep(sleep_s)
-          else:
-              raise SystemExit("Timed out waiting for Cursor autofix to finish")
+              else:
+                  raise SystemExit("Timed out waiting for Cursor autofix to finish")
 
-          # Finalize once: Discord completed/failed + re-review + ready-to-merge.
-          finalize_payload = dict(payload)
-          finalize_payload["finalize"] = True
-          code, final = call(finalize_payload, timeout=300)
-          print(f"finalize: HTTP {code} {json.dumps(final)[:1500]}")
-          if code != 200:
-              raise SystemExit(f"autofix_followup finalize failed: HTTP {code}")
-          open("autofix_followup_response.txt", "w").write(json.dumps(final, indent=2))
-          if final.get("done") and not final.get("ok", True):
-              print("Autofix agent finished unsuccessfully; see Discord.")
+              finalize_payload = dict(payload)
+              finalize_payload["finalize"] = True
+              code, final = call("autofix_followup", finalize_payload, timeout=300)
+              print(f"finalize: HTTP {code} {json.dumps(final)[:1500]}")
+              if code != 200:
+                  raise SystemExit(f"autofix_followup finalize failed: HTTP {code}")
+              return final
+
+          for round_i in range(1, max_rounds + 1):
+              print(f"=== autofix round attempt {round_i}/{max_rounds} ===")
+              code, data = call(
+                  "autofix_pr",
+                  {"repo": repo, "pr_number": pr_number},
+                  timeout=120,
+              )
+              print(f"autofix_pr HTTP {code}: {json.dumps(data)[:800]}")
+              if code != 200:
+                  raise SystemExit(f"autofix_pr failed: HTTP {code} {data}")
+
+              if data.get("loop_protection"):
+                  print("Loop protection reached; stopping.")
+                  break
+
+              if data.get("skipped") or not data.get("launched"):
+                  print(
+                      "Autofix not launched "
+                      f"(reason={data.get('reason') or 'skipped'}). Stopping loop."
+                  )
+                  break
+
+              agent_id = (data.get("agent_id") or "").strip()
+              if not agent_id:
+                  raise SystemExit("autofix launched but agent_id missing")
+
+              final = wait_and_finalize(agent_id, (data.get("run_id") or "").strip())
+              open("autofix_followup_response.txt", "w").write(
+                  json.dumps(final, indent=2)
+              )
+
+              if final.get("ready_to_merge"):
+                  print("Ready to merge after re-review; done.")
+                  break
+              if final.get("loop_protection"):
+                  print("Loop protection after re-review; done.")
+                  break
+              if not final.get("fixes_pushed", True):
+                  print("No fixes pushed this round; stopping loop.")
+                  break
+              # Otherwise continue — Bigas updated the review comment; next autofix_pr
+              # will use it if under the commit-count limit.
+          else:
+              print(f"Completed {max_rounds} autofix attempts in this workflow run.")
           PY

--- a/bigas/resources/cto/autofix/heuristics.py
+++ b/bigas/resources/cto/autofix/heuristics.py
@@ -5,6 +5,21 @@ import re
 from typing import Tuple
 
 AUTOFIX_COMMIT_MARKER = "[bigas-autofix]"
+DEFAULT_AUTOFIX_MAX_ITERATIONS = 3
+
+
+def autofix_max_iterations() -> int:
+    """Max automatic autofix rounds per PR (env BIGAS_CTO_AUTOFIX_MAX_ITERATIONS)."""
+    import os
+
+    raw = (os.environ.get("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS") or "").strip()
+    if not raw:
+        return DEFAULT_AUTOFIX_MAX_ITERATIONS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_AUTOFIX_MAX_ITERATIONS
+
 
 _CLEAN = re.compile(
     r"(?i)\b(looks good( to me)?|lgtm|safe to merge|no (blocking )?issues|"

--- a/bigas/resources/cto/autofix/service.py
+++ b/bigas/resources/cto/autofix/service.py
@@ -11,7 +11,7 @@ from bigas.resources.cto.autofix.cursor_client import (
 )
 from bigas.resources.cto.autofix.heuristics import (
     AUTOFIX_COMMIT_MARKER,
-    latest_commit_is_autofix,
+    autofix_max_iterations,
     review_needs_autofix,
 )
 from bigas.resources.cto.pr_review.github_client import (
@@ -102,6 +102,7 @@ class AutofixService:
         owner, repo_name = repo.split("/", 1)
         pr_url = f"https://github.com/{repo}/pull/{pr_number}"
         repo_url = f"https://github.com/{repo}"
+        max_iters = autofix_max_iterations()
 
         gh = GitHubPRCommentClient(token=self._github_token)
 
@@ -109,14 +110,24 @@ class AutofixService:
             head_sha, head_message = gh.get_pr_head_commit(
                 owner=owner, repo=repo_name, pr_number=pr_number
             )
+            autofix_count = gh.count_autofix_commits(
+                owner, repo_name, pr_number, marker=AUTOFIX_COMMIT_MARKER
+            )
         except GitHubPRCommentError as e:
             raise AutofixError(str(e)) from e
 
-        if latest_commit_is_autofix(head_message) and not force:
+        if autofix_count >= max_iters and not force:
             return {
                 "skipped": True,
-                "reason": f"latest commit already autofix ({head_sha[:8]})",
+                "loop_protection": True,
+                "reason": (
+                    f"loop protection: {autofix_count}/{max_iters} autofix rounds "
+                    f"already on this PR — remaining review comments need manual handling"
+                ),
                 "pr_url": pr_url,
+                "autofix_count": autofix_count,
+                "max_iterations": max_iters,
+                "head_sha": head_sha,
             }
 
         body = (review_body or "").strip()
@@ -135,6 +146,8 @@ class AutofixService:
                     "skipped": True,
                     "reason": "no Bigas review comment found on PR",
                     "pr_url": pr_url,
+                    "autofix_count": autofix_count,
+                    "max_iterations": max_iters,
                 }
             body = found
 
@@ -145,8 +158,12 @@ class AutofixService:
                     "skipped": True,
                     "reason": reason,
                     "pr_url": pr_url,
+                    "autofix_count": autofix_count,
+                    "max_iterations": max_iters,
+                    "review_clean": True,
                 }
 
+        next_round = autofix_count + 1
         prompt = _build_prompt(
             repo=repo, pr_number=pr_number, pr_url=pr_url, review_body=body
         )
@@ -156,7 +173,7 @@ class AutofixService:
                 repo_url=repo_url,
                 pr_url=pr_url,
                 prompt_text=prompt,
-                name=f"Bigas autofix {repo}#{pr_number}",
+                name=f"Bigas autofix {repo}#{pr_number} ({next_round}/{max_iters})",
                 model_id=self._cursor_model,
             )
         except CursorCloudAgentError as e:
@@ -170,6 +187,11 @@ class AutofixService:
             "agent_url": launched.get("agent_url") or "",
             "run_id": launched.get("run_id") or "",
             "forced": bool(force),
+            "autofix_count": autofix_count,
+            "autofix_round": next_round,
+            "max_iterations": max_iters,
+            "head_sha": head_sha,
+            "head_was_autofix": AUTOFIX_COMMIT_MARKER in (head_message or ""),
         }
 
     def poll_status(
@@ -192,6 +214,16 @@ class AutofixService:
         try:
             return gh.get_pr_head_commit(
                 owner=owner, repo=repo_name, pr_number=pr_number
+            )
+        except GitHubPRCommentError as e:
+            raise AutofixError(str(e)) from e
+
+    def count_autofix_commits(self, *, repo: str, pr_number: int) -> int:
+        owner, repo_name = repo.split("/", 1)
+        gh = GitHubPRCommentClient(token=self._github_token)
+        try:
+            return gh.count_autofix_commits(
+                owner, repo_name, pr_number, marker=AUTOFIX_COMMIT_MARKER
             )
         except GitHubPRCommentError as e:
             raise AutofixError(str(e)) from e

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -10,6 +10,7 @@ import requests
 from flask import Blueprint, jsonify, request
 
 from bigas.resources.cto.autofix.heuristics import (
+    autofix_max_iterations,
     latest_commit_is_autofix,
     review_is_ready_to_merge,
 )
@@ -37,6 +38,88 @@ logger = logging.getLogger(__name__)
 # Max characters for a GitHub comment to avoid API errors.
 # The official limit is 65,536 bytes, so 60k chars is a safe buffer.
 MAX_GITHUB_COMMENT_CHARS = 60_000
+
+
+def _jira_final_approval_for_pr(
+    *, repo: str, pr_number: int, pr_url: str, github_token: str
+) -> dict:
+    try:
+        from bigas.resources.product.jira_automation.final_approval import (
+            transition_issue_to_final_approval_for_pr,
+        )
+
+        return transition_issue_to_final_approval_for_pr(
+            repo=repo,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            github_token=github_token,
+        )
+    except Exception:
+        logger.warning("Jira final-approval hook failed", exc_info=True)
+        return {"ok": False, "error": "final_approval_hook_exception"}
+
+
+def _notify_autofix_loop_protection(
+    *,
+    repo: str,
+    pr_number: int,
+    pr_url: str,
+    autofix_count: int,
+    max_iterations: int,
+    github_token: str = "",
+) -> None:
+    msg = (
+        f"**CTO autofix stopped (loop protection)**\n"
+        f"Reached {autofix_count}/{max_iterations} automatic fix rounds without a clean review.\n"
+        f"Remaining review comments need **manual handling**.\n"
+        f"PR: {pr_url}"
+    )
+    _post_to_discord_cto(msg)
+    # Best-effort Jira comment on linked issue (no status change).
+    try:
+        from bigas.resources.product.create_release_notes.jira_client import (
+            JiraClient,
+            JiraConfig,
+        )
+        from bigas.resources.product.jira_automation.config import BIGAS_COMMENT_MARKER
+        from bigas.resources.product.jira_automation.final_approval import (
+            extract_jira_issue_key,
+        )
+
+        token = (github_token or os.environ.get("GITHUB_TOKEN") or "").strip()
+        if not token or "/" not in repo:
+            return
+        owner, name = repo.split("/", 1)
+
+        resp = requests.get(
+            f"https://api.github.com/repos/{owner}/{name}/pulls/{pr_number}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30,
+        )
+        if resp.status_code >= 400:
+            return
+        pr = resp.json() if resp.text else {}
+        issue_key = extract_jira_issue_key(
+            (pr.get("title") or ""),
+            (pr.get("body") or ""),
+            ((pr.get("head") or {}).get("ref") or ""),
+        )
+        if not issue_key:
+            return
+        jira = JiraClient(JiraConfig.from_env())
+        jira.add_comment(
+            issue_key,
+            f"{BIGAS_COMMENT_MARKER} Autofix loop protection "
+            f"({autofix_count}/{max_iterations}).\n"
+            f"Automatic fixes stopped; remaining PR review comments need manual handling.\n"
+            f"Left in current status.\nPR: {pr_url}",
+        )
+    except Exception:
+        logger.warning("Loop-protection Jira comment failed", exc_info=True)
 
 
 def _post_to_discord_cto(message: str) -> None:
@@ -216,6 +299,14 @@ def review_and_comment_pr():
             f"**Ready to merge**\nPR: {pr_url}\n"
             + (f"Comment: {comment_url}" if comment_url else "")
         )
+        jira_final = _jira_final_approval_for_pr(
+            repo=repo,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            github_token=github_token,
+        )
+    else:
+        jira_final = {"skipped": True, "reason": "not_ready"}
 
     return jsonify({
         "success": True,
@@ -224,6 +315,7 @@ def review_and_comment_pr():
         "used_model": review_service._model,
         "ready_to_merge": ready,
         "phase": phase,
+        "jira_final_approval": jira_final,
     })
 
 
@@ -264,7 +356,6 @@ def autofix_pr():
         return jsonify({"error": "pr_number must be a positive integer"}), 400
 
     pr_url = f"https://github.com/{repo}/pull/{pr_number}"
-    _post_to_discord_cto(f"**CTO autofix started**\nPR: {pr_url}")
 
     try:
         service = AutofixService(
@@ -295,15 +386,37 @@ def autofix_pr():
 
     if result.get("skipped"):
         reason = result.get("reason") or "skipped"
-        _post_to_discord_cto(
-            f"**CTO autofix done**\nSkipped.\nReason: {sanitize_error_message(reason)}\nPR: {pr_url}"
-        )
+        if result.get("loop_protection"):
+            _notify_autofix_loop_protection(
+                repo=repo,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                autofix_count=int(result.get("autofix_count") or 0),
+                max_iterations=int(
+                    result.get("max_iterations") or autofix_max_iterations()
+                ),
+                github_token=github_token or "",
+            )
+        elif result.get("review_clean"):
+            _post_to_discord_cto(
+                f"**CTO autofix skipped**\n"
+                f"Review does not need autofix ({sanitize_error_message(reason)}).\n"
+                f"PR: {pr_url}"
+            )
+        else:
+            _post_to_discord_cto(
+                f"**CTO autofix skipped**\n"
+                f"Reason: {sanitize_error_message(reason)}\nPR: {pr_url}"
+            )
         return jsonify({"success": True, **result})
 
     agent_url = result.get("agent_url") or ""
     agent_id = result.get("agent_id") or ""
+    round_n = result.get("autofix_round") or "?"
+    max_n = result.get("max_iterations") or autofix_max_iterations()
     _post_to_discord_cto(
-        f"**CTO autofix launched**\nPR: {pr_url}\nAgent: {agent_url or agent_id}"
+        f"**CTO autofix launched** ({round_n}/{max_n})\n"
+        f"PR: {pr_url}\nAgent: {agent_url or agent_id}"
     )
     return jsonify({"success": True, **result})
 
@@ -468,28 +581,41 @@ def autofix_followup():
         f"**CTO PR re-review after autofix done**\nComment posted: {comment_url}\n\n---\n\n**Review:**"
     )
     _post_to_discord_cto_chunks(review_body)
+
+    autofix_count = 0
+    max_iters = autofix_max_iterations()
+    try:
+        autofix_count = service.count_autofix_commits(repo=repo, pr_number=pr_number)
+    except AutofixError:
+        logger.warning("Could not count autofix commits after re-review", exc_info=True)
+
     jira_final = {"skipped": True, "reason": "not_ready"}
     if ready:
         _post_to_discord_cto(
             f"**Ready to merge**\nPR: {pr_url}\nComment: {comment_url}"
         )
-        try:
-            from bigas.resources.product.jira_automation.final_approval import (
-                transition_issue_to_final_approval_for_pr,
-            )
-
-            jira_final = transition_issue_to_final_approval_for_pr(
-                repo=repo,
-                pr_number=pr_number,
-                pr_url=pr_url,
-                github_token=gh_token,
-            )
-        except Exception:
-            logger.warning("Jira final-approval hook failed", exc_info=True)
-            jira_final = {"ok": False, "error": "final_approval_hook_exception"}
+        jira_final = _jira_final_approval_for_pr(
+            repo=repo,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            github_token=gh_token,
+        )
+    elif autofix_count >= max_iters:
+        _notify_autofix_loop_protection(
+            repo=repo,
+            pr_number=pr_number,
+            pr_url=pr_url,
+            autofix_count=autofix_count,
+            max_iterations=max_iters,
+            github_token=gh_token,
+        )
     else:
         _post_to_discord_cto(
-            f"**CTO autofix follow-up**\nPR still has findings after autofix.\nPR: {pr_url}"
+            f"**CTO autofix follow-up**\n"
+            f"PR still has findings after autofix round "
+            f"{autofix_count}/{max_iters}.\n"
+            f"Another autofix round may run if under the limit.\n"
+            f"PR: {pr_url}"
         )
 
     base.update({
@@ -498,6 +624,9 @@ def autofix_followup():
         "comment_url": comment_url,
         "ready_to_merge": ready,
         "fixes_pushed": True,
+        "autofix_count": autofix_count,
+        "max_iterations": max_iters,
+        "loop_protection": (not ready) and autofix_count >= max_iters,
         "used_model": review_service._model,
         "jira_final_approval": jira_final,
     })

--- a/bigas/resources/cto/pr_review/github_client.py
+++ b/bigas/resources/cto/pr_review/github_client.py
@@ -202,3 +202,62 @@ class GitHubPRCommentClient:
                 f"GitHub API error {resp.status_code}: {resp.text[:300]}"
             )
         return resp.text or ""
+
+    def list_pr_commit_messages(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        max_commits: int = 250,
+    ) -> list[str]:
+        """Return commit messages on the PR (newest last), paginated."""
+        messages: list[str] = []
+        page = 1
+        per_page = 100
+        while len(messages) < max_commits:
+            url = (
+                f"https://api.github.com/repos/{owner}/{repo}/pulls/"
+                f"{pr_number}/commits"
+            )
+            resp = requests.get(
+                url,
+                headers=self._headers,
+                params={"per_page": per_page, "page": page},
+                timeout=30,
+            )
+            if resp.status_code == 404:
+                raise GitHubPRCommentError(
+                    f"Repository or PR not found: {owner}/{repo}#{pr_number}."
+                )
+            if resp.status_code == 401:
+                raise GitHubPRCommentError("GitHub token is invalid or expired.")
+            if resp.status_code == 403:
+                raise GitHubPRCommentError(
+                    "GitHub returned 403. Check token scopes and rate limits."
+                )
+            resp.raise_for_status()
+            batch = resp.json() if resp.text else []
+            if not isinstance(batch, list) or not batch:
+                break
+            for item in batch:
+                msg = ((item.get("commit") or {}).get("message") or "").strip()
+                messages.append(msg)
+                if len(messages) >= max_commits:
+                    break
+            if len(batch) < per_page:
+                break
+            page += 1
+        return messages
+
+    def count_autofix_commits(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        marker: str = "[bigas-autofix]",
+    ) -> int:
+        """Count PR commits whose message contains the autofix marker."""
+        messages = self.list_pr_commit_messages(owner, repo, pr_number)
+        return sum(1 for m in messages if marker in m)

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -7,16 +7,18 @@ After Bigas posts a PR review comment, you can optionally launch a **Cursor clou
 ```text
 PR opened/push
   → review_and_comment_pr → GitHub comment + Discord
-       → if LGTM: Discord "Ready to merge"
-  → if repo var BIGAS_AUTO_FIX=true
+       → if LGTM: Discord "Ready to merge" + Jira Final approval (if issue key on PR)
+  → if repo var BIGAS_AUTO_FIX=true (Actions loop, up to 3 rounds):
       → autofix_pr
-          → skip if review is LGTM / nits-only, or last commit is [bigas-autofix]
+          → skip if review is LGTM / nits-only
+          → skip with loop protection if PR already has ≥3 [bigas-autofix] commits
           → else launch Cursor cloud agent (workOnCurrentBranch)
       → poll autofix_followup until agent terminal
-          → Discord: autofix completed / failed
+          → Discord: autofix completed / failed / without commits
           → re-review updated diff
-          → Discord: re-review done
-          → if LGTM: Discord "Ready to merge"
+          → if LGTM: Discord "Ready to merge" + Jira Final approval
+          → else if under 3 rounds: next autofix round with updated review
+          → else: Discord + Jira comment — loop protection, manual handling
 ```
 
 No automerge in v1.
@@ -27,7 +29,10 @@ No automerge in v1.
 2. Cursor GitHub app installed on the target repos (same as Cloud Agents in the IDE).
 3. Existing `GITHUB_TOKEN` (used to read the Bigas review comment + PR head commit).
 
-Optional: `BIGAS_CTO_AUTOFIX_MODEL` (Cursor model id). Omit to use Cursor’s default.
+Optional:
+
+- `BIGAS_CTO_AUTOFIX_MODEL` (Cursor model id). Omit to use Cursor’s default.
+- `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default `3`) — max `[bigas-autofix]` commits per PR before loop protection.
 
 ## Repo config
 
@@ -39,7 +44,7 @@ In the product repo (Actions variables/secrets):
 | `BIGAS_API_KEY` | secret | Bigas access key |
 | `BIGAS_AUTO_FIX` | variable | `true` to enable autofix step |
 
-Copy the latest [pr-review.yml](../.github/workflows/pr-review.yml) so it includes the autofix step.
+Copy the latest [pr-review.yml](../.github/workflows/pr-review.yml) so it includes the autofix loop.
 
 ## API
 
@@ -53,9 +58,10 @@ Copy the latest [pr-review.yml](../.github/workflows/pr-review.yml) so it includ
 }
 ```
 
-- `force: true` bypasses clean-review and `[bigas-autofix]` loop guards (smoke/debug only).
-- Success (launched): `{ "success": true, "launched": true, "agent_url": "...", "agent_id": "bc-..." }`
+- `force: true` bypasses clean-review and loop-protection guards (smoke/debug only).
+- Success (launched): `{ "success": true, "launched": true, "autofix_round": 2, "max_iterations": 3, ... }`
 - Success (skipped): `{ "success": true, "skipped": true, "reason": "..." }`
+- Loop protection: `{ "skipped": true, "loop_protection": true, "autofix_count": 3, ... }`
 
 ### `POST /mcp/tools/autofix_followup`
 
@@ -73,6 +79,7 @@ Polled by GitHub Actions after launch:
 - Not done yet: `{ "done": false, "status": "RUNNING", ... }`
 - Done + re-reviewed: `{ "done": true, "ok": true, "rereviewed": true, "ready_to_merge": true, "comment_url": "..." }`
 - Done but no `[bigas-autofix]` commit (e.g. agent asked for confirmation): Discord warning, `{ "fixes_pushed": false, "rereviewed": false }` — no fake “completed” message
+- After max rounds without LGTM: `{ "loop_protection": true }` + Discord/Jira manual-handling notice
 
 The autofix prompt instructs the agent **not** to ask for confirmation and to push fixes immediately.
 
@@ -80,5 +87,5 @@ The autofix prompt instructs the agent **not** to ask for confirmation and to pu
 
 - Skip when review looks like LGTM / no actionable findings
 - Skip when only non-blocking nits
-- Skip when latest PR head commit message contains `[bigas-autofix]`
+- Stop after `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default 3) commits containing `[bigas-autofix]`
 - Agent prompt requires that marker in any commits it creates

--- a/env.example
+++ b/env.example
@@ -97,6 +97,7 @@ GITHUB_TOKEN=your_github_pat_here
 CURSOR_API_KEY=your_cursor_api_key_here
 # Optional: Cursor model id for autofix (omit for Cursor default).
 # BIGAS_CTO_AUTOFIX_MODEL=composer-2.5
+# BIGAS_CTO_AUTOFIX_MAX_ITERATIONS=3
 # Optional: model for CTO PR review. Override via BIGAS_CTO_PR_REVIEW_MODEL or request body llm_model.
 # BIGAS_CTO_PR_REVIEW_MODEL=gemini-3.1-pro-preview
 # Optional: max diff size in characters (default 150000). Truncation note is prepended if exceeded.

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -42,6 +42,17 @@ def test_autofix_commit_marker():
     assert not latest_commit_is_autofix("fix: auth")
 
 
+def test_autofix_max_iterations_env(monkeypatch):
+    from bigas.resources.cto.autofix.heuristics import autofix_max_iterations
+
+    monkeypatch.delenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", raising=False)
+    assert autofix_max_iterations() == 3
+    monkeypatch.setenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", "5")
+    assert autofix_max_iterations() == 5
+    monkeypatch.setenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", "0")
+    assert autofix_max_iterations() == 1
+
+
 def test_autofix_prompt_forbids_confirmation():
     prompt = _build_prompt(
         repo="mckort/bigas",


### PR DESCRIPTION
## Summary
- Up to **3** \`[bigas-autofix]\` rounds per PR (configurable via \`BIGAS_CTO_AUTOFIX_MAX_ITERATIONS\`).
- After each autofix: re-review; if LGTM → Discord Ready to merge + **Jira Final approval**.
- After 3 rounds without LGTM → loop protection Discord + Jira comment (manual handling).
- Actions workflow loops autofix/re-review in one job (timeout 120m).
- Initial review LGTM also triggers Jira Final approval.

## Test plan
- [x] unit tests
- [ ] deploy Cloud Run
- [ ] push workflow to vcfieldassistant
- [ ] re-run PR #9 review/autofix path