### PR TITLE
Raise autofix max iterations to 5

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -77,13 +77,13 @@ jobs:
           echo "Bigas returned 200 OK."
           cat response_body.txt || true
 
-      - name: Autofix loop (up to 3 rounds) + re-review
+      - name: Autofix loop (up to 5 rounds) + re-review
         if: ${{ vars.BIGAS_AUTO_FIX == 'true' }}
         env:
           BIGAS_URL: ${{ vars.BIGAS_URL }}
           BIGAS_API_KEY: ${{ secrets.BIGAS_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MAX_AUTOFIX_ROUNDS: "3"
+          MAX_AUTOFIX_ROUNDS: "5"
         run: |
           python3 <<'PY'
           import json, os, time, urllib.error, urllib.request
@@ -92,7 +92,7 @@ jobs:
           api_key = os.environ["BIGAS_API_KEY"]
           repo = os.environ["GITHUB_REPOSITORY"]
           pr_number = int(os.environ["PR_NUMBER"])
-          max_rounds = int(os.environ.get("MAX_AUTOFIX_ROUNDS") or "3")
+          max_rounds = int(os.environ.get("MAX_AUTOFIX_ROUNDS") or "5")
 
           def call(path, body_obj, timeout=180):
               data = json.dumps(body_obj).encode()

--- a/bigas/resources/cto/autofix/heuristics.py
+++ b/bigas/resources/cto/autofix/heuristics.py
@@ -5,7 +5,7 @@ import re
 from typing import Tuple
 
 AUTOFIX_COMMIT_MARKER = "[bigas-autofix]"
-DEFAULT_AUTOFIX_MAX_ITERATIONS = 3
+DEFAULT_AUTOFIX_MAX_ITERATIONS = 5
 
 
 def autofix_max_iterations() -> int:

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -8,16 +8,16 @@ After Bigas posts a PR review comment, you can optionally launch a **Cursor clou
 PR opened/push
   → review_and_comment_pr → GitHub comment + Discord
        → if LGTM: Discord "Ready to merge" + Jira Final approval (if issue key on PR)
-  → if repo var BIGAS_AUTO_FIX=true (Actions loop, up to 3 rounds):
+  → if repo var BIGAS_AUTO_FIX=true (Actions loop, up to 5 rounds):
       → autofix_pr
           → skip if review is LGTM / nits-only
-          → skip with loop protection if PR already has ≥3 [bigas-autofix] commits
+          → skip with loop protection if PR already has ≥5 [bigas-autofix] commits
           → else launch Cursor cloud agent (workOnCurrentBranch)
       → poll autofix_followup until agent terminal
           → Discord: autofix completed / failed / without commits
           → re-review updated diff
           → if LGTM: Discord "Ready to merge" + Jira Final approval
-          → else if under 3 rounds: next autofix round with updated review
+          → else if under 5 rounds: next autofix round with updated review
           → else: Discord + Jira comment — loop protection, manual handling
 ```
 
@@ -32,7 +32,7 @@ No automerge in v1.
 Optional:
 
 - `BIGAS_CTO_AUTOFIX_MODEL` (Cursor model id). Omit to use Cursor’s default.
-- `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default `3`) — max `[bigas-autofix]` commits per PR before loop protection.
+- `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default `5`) — max `[bigas-autofix]` commits per PR before loop protection.
 
 ## Repo config
 
@@ -59,9 +59,9 @@ Copy the latest [pr-review.yml](../.github/workflows/pr-review.yml) so it includ
 ```
 
 - `force: true` bypasses clean-review and loop-protection guards (smoke/debug only).
-- Success (launched): `{ "success": true, "launched": true, "autofix_round": 2, "max_iterations": 3, ... }`
+- Success (launched): `{ "success": true, "launched": true, "autofix_round": 2, "max_iterations": 5, ... }`
 - Success (skipped): `{ "success": true, "skipped": true, "reason": "..." }`
-- Loop protection: `{ "skipped": true, "loop_protection": true, "autofix_count": 3, ... }`
+- Loop protection: `{ "skipped": true, "loop_protection": true, "autofix_count": 5, ... }`
 
 ### `POST /mcp/tools/autofix_followup`
 
@@ -87,5 +87,5 @@ The autofix prompt instructs the agent **not** to ask for confirmation and to pu
 
 - Skip when review looks like LGTM / no actionable findings
 - Skip when only non-blocking nits
-- Stop after `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default 3) commits containing `[bigas-autofix]`
+- Stop after `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default 5) commits containing `[bigas-autofix]`
 - Agent prompt requires that marker in any commits it creates

--- a/env.example
+++ b/env.example
@@ -97,7 +97,7 @@ GITHUB_TOKEN=your_github_pat_here
 CURSOR_API_KEY=your_cursor_api_key_here
 # Optional: Cursor model id for autofix (omit for Cursor default).
 # BIGAS_CTO_AUTOFIX_MODEL=composer-2.5
-# BIGAS_CTO_AUTOFIX_MAX_ITERATIONS=3
+# BIGAS_CTO_AUTOFIX_MAX_ITERATIONS=5
 # Optional: model for CTO PR review. Override via BIGAS_CTO_PR_REVIEW_MODEL or request body llm_model.
 # BIGAS_CTO_PR_REVIEW_MODEL=gemini-3.1-pro-preview
 # Optional: max diff size in characters (default 150000). Truncation note is prepended if exceeded.

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -46,9 +46,9 @@ def test_autofix_max_iterations_env(monkeypatch):
     from bigas.resources.cto.autofix.heuristics import autofix_max_iterations
 
     monkeypatch.delenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", raising=False)
-    assert autofix_max_iterations() == 3
-    monkeypatch.setenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", "5")
     assert autofix_max_iterations() == 5
+    monkeypatch.setenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", "7")
+    assert autofix_max_iterations() == 7
     monkeypatch.setenv("BIGAS_CTO_AUTOFIX_MAX_ITERATIONS", "0")
     assert autofix_max_iterations() == 1
 


### PR DESCRIPTION
## Summary
- Default \`BIGAS_CTO_AUTOFIX_MAX_ITERATIONS\` / Actions \`MAX_AUTOFIX_ROUNDS\`: **5** (was 3).

## Test plan
- [x] unit test default == 5
- [ ] deploy + merge
- [ ] sync vcfieldassistant \`pr-review.yml\`