### PR TITLE
Improve CTO PR review completeness and autofix Minor bundling

### DIFF
--- a/bigas/resources/cto/autofix/heuristics.py
+++ b/bigas/resources/cto/autofix/heuristics.py
@@ -22,8 +22,12 @@ def autofix_max_iterations() -> int:
 
 
 _CLEAN = re.compile(
-    r"(?i)\b(looks good( to me)?|lgtm|safe to merge|no (blocking )?issues|"
-    r"nothing to fix|approved as[- ]is)\b"
+    r"(?i)\b(looks good( to me)?|lgtm|safe to merge|ready to merge|"
+    r"no (blocking )?issues|nothing to fix|approved as[- ]is)\b"
+)
+# Explicit severity headers from the structured review format.
+_SECTION_HEADER = re.compile(
+    r"(?im)^\s{0,3}#{1,6}\s*(Blockers|Important|Minor)\s*$"
 )
 # Note: (?<!non-) avoids matching the "blocking" inside "non-blocking".
 _ACTIONABLE = re.compile(
@@ -31,8 +35,40 @@ _ACTIONABLE = re.compile(
     r"broken|incorrect|regression|failing test|high severity|do not merge)\b"
 )
 _NIT_ONLY = re.compile(
-    r"(?i)\b(non[- ]blocking|nit\b|minor suggestion|optional|style only)\b"
+    r"(?i)\b(non[- ]blocking|nit\b|minor suggestion|optional|style only|###\s*Minor)\b"
 )
+_SOFT_ONLY = re.compile(
+    r"(?i)\b(consider|optional|todo\b|nice to have|future cleanup|non[- ]blocking|"
+    r"nit\b|minor suggestion|style only)\b"
+)
+
+
+def _section_bodies(review_body: str) -> dict[str, str]:
+    """Parse ### Blockers / ### Important / ### Minor section bodies if present."""
+    matches = list(_SECTION_HEADER.finditer(review_body or ""))
+    if not matches:
+        return {}
+    sections: dict[str, str] = {}
+    for i, match in enumerate(matches):
+        name = match.group(1).lower()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(review_body)
+        sections[name] = (review_body[start:end] or "").strip()
+    return sections
+
+
+def _section_has_findings(body: str) -> bool:
+    text = (body or "").strip()
+    if not text:
+        return False
+    # Common empty markers from the structured prompt.
+    if re.fullmatch(r"(?is)none\.?", text):
+        return False
+    if re.fullmatch(r"(?is)n/?a\.?", text):
+        return False
+    if re.fullmatch(r"(?is)no (issues|findings|blockers|important issues)\.?", text):
+        return False
+    return True
 
 
 def review_needs_autofix(review_body: str) -> Tuple[bool, str]:
@@ -41,6 +77,7 @@ def review_needs_autofix(review_body: str) -> Tuple[bool, str]:
 
     Autofix runs when the review has clear actionable/blocking language.
     Clean LGTM reviews and nit-only reviews are skipped.
+    Soft "consider/TODO/minor" language alone does not trigger autofix.
     """
     body = (review_body or "").strip()
     if not body:
@@ -48,15 +85,25 @@ def review_needs_autofix(review_body: str) -> Tuple[bool, str]:
     if "<!-- bigas-autofix-skip -->" in body:
         return False, "review contains autofix-skip marker"
 
+    sections = _section_bodies(body)
+    if sections:
+        if _section_has_findings(sections.get("blockers", "")):
+            return True, "actionable findings in review"
+        if _section_has_findings(sections.get("important", "")):
+            return True, "actionable findings in review"
+        # Structured review with empty Blockers/Important → never autofix on Minor alone.
+        return False, "only non-blocking / nit suggestions"
+
     has_actionable = bool(_ACTIONABLE.search(body))
     looks_clean = bool(_CLEAN.search(body))
     nit_only = bool(_NIT_ONLY.search(body)) and not has_actionable
+    soft_only = bool(_SOFT_ONLY.search(body)) and not has_actionable
 
     if has_actionable:
         return True, "actionable findings in review"
     if looks_clean:
         return False, "review looks clean (LGTM)"
-    if nit_only:
+    if nit_only or soft_only:
         return False, "only non-blocking / nit suggestions"
 
     # Ambiguous middle ground: skip by default to avoid noisy agent runs.
@@ -77,6 +124,11 @@ def review_is_ready_to_merge(review_body: str) -> bool:
         return False
     # Explicit clean signal, or only nits / ambiguous-but-not-actionable after a review ran.
     if _CLEAN.search(body):
+        return True
+    sections = _section_bodies(body)
+    if sections and not _section_has_findings(sections.get("blockers", "")) and not _section_has_findings(
+        sections.get("important", "")
+    ):
         return True
     if _NIT_ONLY.search(body) and not _ACTIONABLE.search(body):
         return True

--- a/bigas/resources/cto/autofix/service.py
+++ b/bigas/resources/cto/autofix/service.py
@@ -37,9 +37,9 @@ Pull request: {pr_url}
 {review_body}
 
 ## Instructions
-1. Fix only clear, actionable problems called out in the review (bugs, broken behavior, security, must-fix / blocking items).
-2. Skip pure nits and non-blocking style suggestions unless they are trivial one-line fixes already implied by the review.
-3. Do not expand scope, refactor unrelated code, or change public APIs unless required by a finding.
+1. Fix all Blockers and Important items called out in the review.
+2. Also fix Minor items listed in the same review — they ride along in this round when Blockers/Important already triggered autofix.
+3. Do not invent extra polish beyond what the review lists. Do not expand scope or refactor unrelated code.
 4. Push commits directly to this PR's head branch (already checked out for you).
 5. Every commit message you create MUST include the exact marker `{AUTOFIX_COMMIT_MARKER}`.
 6. Do not merge the PR, do not force-push, do not rewrite history, and do not open a new PR.

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -241,9 +241,26 @@ def review_and_comment_pr():
     owner, repo_name = repo.split("/", 1)
     pr_url = f"https://github.com/{repo}/pull/{pr_number}"
 
+    previous_review = None
+    if phase == "post_autofix":
+        try:
+            previous_review = GitHubPRCommentClient(token=github_token).get_marked_comment_body(
+                owner=owner,
+                repo=repo_name,
+                pr_number=pr_number,
+                marker=BIGAS_REVIEW_MARKER,
+            )
+        except GitHubPRCommentError:
+            logger.warning("Could not load previous Bigas review for post_autofix", exc_info=True)
+
     try:
         review_service = PRReviewService(openai_model=llm_model)
-        review_body = review_service.review(diff=diff, instructions=instructions)
+        review_body = review_service.review(
+            diff=diff,
+            instructions=instructions,
+            phase=phase,  # type: ignore[arg-type]
+            previous_review=previous_review,
+        )
     except PRReviewError as e:
         logger.warning("PR review failed: %s", e)
         _post_to_discord_cto(f"**CTO PR review done**\nNo comment posted.\nReason: {sanitize_error_message(str(e))}")
@@ -540,10 +557,25 @@ def autofix_followup():
         )
         return jsonify({"error": err, **base, "finalized": True, "rereviewed": False}), 502
 
+    gh_token = github_token or os.environ.get("GITHUB_TOKEN") or ""
     _post_to_discord_cto(f"**CTO PR re-review after autofix started**\nPR: {pr_url}")
+    previous_review = None
+    try:
+        previous_review = GitHubPRCommentClient(token=gh_token).get_marked_comment_body(
+            owner=owner,
+            repo=repo_name,
+            pr_number=pr_number,
+            marker=BIGAS_REVIEW_MARKER,
+        )
+    except GitHubPRCommentError:
+        logger.warning("Could not load previous Bigas review before post_autofix", exc_info=True)
     try:
         review_service = PRReviewService()
-        review_body = review_service.review(diff=diff)
+        review_body = review_service.review(
+            diff=diff,
+            phase="post_autofix",
+            previous_review=previous_review,
+        )
     except PRReviewError as e:
         err = sanitize_error_message(str(e))
         _post_to_discord_cto(
@@ -557,7 +589,6 @@ def autofix_followup():
             + "\n\n---\n\n_Review truncated for GitHub comment length._"
         )
 
-    gh_token = github_token or os.environ.get("GITHUB_TOKEN") or ""
     comment_url = ""
     try:
         client = GitHubPRCommentClient(token=gh_token)

--- a/bigas/resources/cto/pr_review/prompts.py
+++ b/bigas/resources/cto/pr_review/prompts.py
@@ -1,25 +1,115 @@
 """Prompts for the CTO PR review (Codex) model."""
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
-PR_REVIEW_SYSTEM_PROMPT = """You are a senior engineer performing a pull request review.
-Your role is to give concise, actionable feedback that helps maintain quality and catch issues early.
+ReviewPhase = Literal["initial", "post_autofix"]
+
+# Shared output contract so autofix heuristics can classify severity reliably.
+_REVIEW_FORMAT = """
+Output format (use these exact markdown headers):
+### Blockers
+Issues that must be fixed before merge (security, data loss, correctness bugs).
+If none: write "None."
+
+### Important
+High-priority issues that should be fixed before merge (validation gaps, leaky
+resources, race/async lifecycle bugs, silent data integrity failures).
+If none: write "None."
+
+### Minor
+Non-blocking nits and optional polish. Keep brief.
+If none: write "None."
+
+End with one short overall verdict sentence. If there are no blockers and no
+important issues, include the phrase "ready to merge".
+""".strip()
+
+PR_REVIEW_SYSTEM_PROMPT = f"""You are a senior engineer performing a pull request review.
+Your role is to catch real issues early with specific, actionable feedback.
 
 Guidelines:
-- Focus on logic, correctness, security, maintainability, and clear naming. Mention style only when it affects readability.
-- Be specific: reference file/line or code snippets where relevant. Avoid vague comments.
-- Prioritize: call out blockers and important issues first; minor suggestions can be brief.
-- Keep the review scannable: use short paragraphs or bullets. Use markdown (headers, code fences) where it helps.
-- Do not invent problems. If the diff looks good, say so briefly and add one or two optional improvements if any.
-- Return only the review text—no meta-commentary, no "Here is my review" wrapper. Start directly with the review content."""
+- Focus on logic, correctness, security, maintainability, and clear naming.
+- Be specific: reference file paths and code snippets where relevant.
+- Do not invent problems. Prefer fewer true issues over padded nits.
+- Return only the review text—no meta-commentary, no "Here is my review" wrapper.
+- Start directly with the review content.
+
+{_REVIEW_FORMAT}
+"""
+
+PR_REVIEW_INITIAL_SYSTEM_PROMPT = f"""You are a senior engineer performing an exhaustive first-pass pull request review.
+Your job is completeness on the first pass: surface nearly all real blockers and
+important issues now, so follow-up rounds are not needed for issues that were
+already present in the diff.
+
+Guidelines:
+- Prefer completeness over brevity for Blockers and Important. Minor can stay short.
+- Be specific: reference file paths and code snippets where relevant.
+- Do not invent problems. If something looks fine, leave it out.
+- Use this checklist while reviewing the diff (skip items that do not apply):
+  1. Input validation / authz before persistence
+  2. Null/empty/type coercion bugs (especially LLM or JSON parsing)
+  3. Async jobs/workers: failure paths, stuck statuses, retries
+  4. Frontend async: polling, abort/unmount, pending/failed UX
+  5. Storage/file lifecycle: upload failure cleanup, delete on accept/discard, TTL orphans
+  6. Transactions / duplicate detection / limits that can silently truncate
+  7. Error handling that hides failures from users
+  8. UI edge cases: empty states, negative values, sorting stability
+- Return only the review text—no meta-commentary wrapper.
+
+{_REVIEW_FORMAT}
+"""
+
+PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT = f"""You are a senior engineer verifying a pull request after an autofix round.
+Your job is verification, not a fresh open-ended review.
+
+Guidelines:
+- Primary task: check whether each previously reported Blocker/Important item is fixed.
+- Only report NEW issues if they are true blockers or important correctness/security problems
+  introduced by the autofix, or clearly still broken from the previous list.
+- Do NOT invent new minor nits, style suggestions, or optional TODOs that were not
+  in the previous review. Put residual optional polish under Minor only if essential.
+- If previous Blockers/Important are resolved and no new blockers/important remain,
+  say the PR is ready to merge.
+- Be specific with file paths. Return only the review text.
+
+{_REVIEW_FORMAT}
+"""
 
 
-def build_pr_review_user_prompt(diff: str, instructions: Optional[str] = None) -> str:
+def system_prompt_for_phase(phase: ReviewPhase = "initial") -> str:
+    if phase == "post_autofix":
+        return PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT
+    return PR_REVIEW_INITIAL_SYSTEM_PROMPT
+
+
+def build_pr_review_user_prompt(
+    diff: str,
+    instructions: Optional[str] = None,
+    *,
+    phase: ReviewPhase = "initial",
+    previous_review: Optional[str] = None,
+) -> str:
     """Build the user prompt with the PR diff and optional custom instructions."""
-    parts = ["Review the following pull request diff."]
+    if phase == "post_autofix":
+        parts = [
+            "Re-review this pull request after autofix.",
+            "Verify previous findings first; only raise new Blockers/Important if truly warranted.",
+        ]
+    else:
+        parts = [
+            "Review the following pull request diff thoroughly in one pass.",
+            "Aim to list all Blockers and Important issues now.",
+        ]
+
+    if previous_review and previous_review.strip():
+        parts.append("\n\nPrevious Bigas review (verify these items):\n")
+        parts.append(previous_review.strip())
+
     if instructions and instructions.strip():
-        parts.append(f"\nAdditional instructions from the team:\n{instructions.strip()}")
+        parts.append(f"\n\nAdditional instructions from the team:\n{instructions.strip()}")
+
     parts.append("\n\nDiff:\n")
     parts.append(diff)
     return "".join(parts)

--- a/bigas/resources/cto/pr_review/service.py
+++ b/bigas/resources/cto/pr_review/service.py
@@ -11,8 +11,9 @@ from typing import Optional
 from bigas.llm.factory import get_llm_client
 
 from bigas.resources.cto.pr_review.prompts import (
-    PR_REVIEW_SYSTEM_PROMPT,
+    ReviewPhase,
     build_pr_review_user_prompt,
+    system_prompt_for_phase,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,9 @@ class PRReviewService:
         self,
         diff: str,
         instructions: Optional[str] = None,
+        *,
+        phase: ReviewPhase = "initial",
+        previous_review: Optional[str] = None,
     ) -> str:
         """
         Run AI review on the given diff. Returns markdown review text.
@@ -97,15 +101,26 @@ class PRReviewService:
             diff = diff[:max_chars] + "\n\n... (diff truncated for length)\n"
             truncated_note = f"_Review is based on the first {max_chars} characters of the diff._\n\n"
 
-        user_prompt = build_pr_review_user_prompt(diff=diff, instructions=instructions)
+        if phase not in {"initial", "post_autofix"}:
+            phase = "initial"
+
+        user_prompt = build_pr_review_user_prompt(
+            diff=diff,
+            instructions=instructions,
+            phase=phase,
+            previous_review=previous_review,
+        )
+        system_prompt = system_prompt_for_phase(phase)
+        # Slightly lower temperature for more consistent, checklist-driven reviews.
+        temperature = 0.1 if phase == "initial" else 0.0
         try:
             content = self._llm.complete(
                 messages=[
-                    {"role": "system", "content": PR_REVIEW_SYSTEM_PROMPT},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
                 max_tokens=_max_review_tokens(),
-                temperature=0.3,
+                temperature=temperature,
             )
         except Exception as e:
             logger.error("PR review LLM call failed", exc_info=True)

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -86,6 +86,9 @@ The autofix prompt instructs the agent **not** to ask for confirmation and to pu
 ## Guards
 
 - Skip when review looks like LGTM / no actionable findings
-- Skip when only non-blocking nits
+- Skip when only non-blocking nits (including structured `### Minor` with empty Blockers/Important)
+- Skip soft-only language (`consider`, `TODO`, `optional`) unless Blockers/Important are present
+- When autofix *does* run (Blockers/Important present), the agent also fixes Minor items from the same review
 - Stop after `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default 5) commits containing `[bigas-autofix]`
 - Agent prompt requires that marker in any commits it creates
+- Re-review after autofix uses a verification prompt and the previous Bigas comment, so it should not invent a fresh set of nits each round

--- a/docs/cto-pr-review.md
+++ b/docs/cto-pr-review.md
@@ -42,6 +42,7 @@ Optional autofix (Cursor cloud agent): set repository variable `BIGAS_AUTO_FIX=t
   - `pr_number` (required): integer
   - `diff` (required): PR diff text (e.g. from `git diff main...HEAD` or GitHub API)
   - `instructions` (optional): extra instructions for the reviewer
+  - `phase` (optional): `"initial"` (default) or `"post_autofix"`. Initial reviews use an exhaustive checklist prompt; post-autofix reviews verify the previous Bigas comment and only raise new blockers/important issues.
   - `github_token` (optional): override GitHub PAT (if not using `GITHUB_TOKEN` env)
   - `llm_model` (optional): override model for this request
 

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -37,6 +37,41 @@ def test_important_runs():
     assert "actionable" in reason
 
 
+def test_structured_important_runs():
+    ok, reason = review_needs_autofix(
+        "### Blockers\nNone.\n\n"
+        "### Important\n"
+        "- Validate body.samples before writing to Firestore.\n\n"
+        "### Minor\n"
+        "- Consider extracting a helper.\n\n"
+        "Otherwise solid.\n"
+    )
+    assert ok is True
+    assert "actionable" in reason
+
+
+def test_structured_minor_only_skips():
+    ok, reason = review_needs_autofix(
+        "### Blockers\nNone.\n\n"
+        "### Important\nNone.\n\n"
+        "### Minor\n"
+        "- Consider extracting a helper.\n\n"
+        "Ready to merge.\n"
+    )
+    assert ok is False
+    assert "nit" in reason or "non-blocking" in reason
+
+
+def test_soft_consider_only_skips():
+    ok, reason = review_needs_autofix(
+        "A few optional polish items:\n"
+        "- Consider adding an AbortController for polling.\n"
+        "- Consider leaving a TODO for the duplicate query.\n"
+        "The rest of the implementation looks solid and ready to merge!\n"
+    )
+    assert ok is False
+
+
 def test_autofix_commit_marker():
     assert latest_commit_is_autofix("fix: auth [bigas-autofix]")
     assert not latest_commit_is_autofix("fix: auth")
@@ -62,6 +97,8 @@ def test_autofix_prompt_forbids_confirmation():
     )
     assert "Do NOT ask for confirmation" in prompt
     assert "apply the fixes and push commits immediately" in prompt
+    assert "Also fix Minor items" in prompt
+    assert "Fix all Blockers and Important" in prompt
 
 
 def test_autofix_looks_like_confirmation_stop():


### PR DESCRIPTION
## Summary
- Exhaustive checklist-driven initial PR reviews with structured Blockers/Important/Minor sections
- Post-autofix re-reviews verify the previous Bigas comment instead of inventing new nits
- When autofix runs for Blockers/Important, Minor findings from the same review are fixed too; Minor-only reviews still skip autofix

## Test plan
- [x] `pytest tests/test_autofix_heuristics.py`
- [ ] Deploy and run a PR review to confirm structured sections + autofix behavior