### PR TITLE
fix: stop Discord CTO reviews from truncating mid-message

### DIFF
--- a/bigas/discord_webhook.py
+++ b/bigas/discord_webhook.py
@@ -1,0 +1,98 @@
+"""Shared Discord webhook helpers for short and long messages."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DISCORD_HTTP_TIMEOUT = int(os.environ.get("DISCORD_HTTP_TIMEOUT", "10"))
+
+
+def post_to_discord(webhook_url: Optional[str], message: str) -> bool:
+    """
+    Post a single message to Discord, truncating hard at 2000 characters.
+    Returns True if the request succeeded (HTTP 204), False otherwise.
+
+    Retries briefly on HTTP 429 so multi-part posts from post_long_to_discord
+    are less likely to drop continuation chunks.
+
+    NOTE: For longer, multi-part messages use post_long_to_discord instead.
+    """
+    if (
+        not webhook_url
+        or webhook_url.strip() == ""
+        or webhook_url.strip().lower().startswith("placeholder")
+    ):
+        logger.info("Discord webhook URL not provided or is placeholder, skipping Discord notification")
+        return False
+
+    if len(message) > 2000:
+        message = message[:1997] + "..."
+    data = {"content": message}
+    for _attempt in range(4):
+        try:
+            response = requests.post(
+                webhook_url,
+                json=data,
+                timeout=DISCORD_HTTP_TIMEOUT,
+            )
+            if response.status_code == 204:
+                logger.info("Successfully posted to Discord")
+                return True
+            if response.status_code == 429:
+                retry_after = 1.0
+                try:
+                    retry_after = float(response.headers.get("Retry-After") or "1")
+                except ValueError:
+                    retry_after = 1.0
+                time.sleep(min(max(retry_after, 0.5), 5.0))
+                continue
+            logger.error("Failed to post to Discord: %s, %s", response.status_code, response.text)
+            return False
+        except Exception as e:
+            logger.error("Error posting to Discord: %s", e)
+            return False
+    logger.error("Failed to post to Discord after retries (rate limited)")
+    return False
+
+
+def post_long_to_discord(webhook_url: Optional[str], text: str, chunk_size: int = 1900) -> None:
+    """
+    Post a long markdown-like text to Discord, splitting it into multiple
+    messages that respect Discord's 2000 character limit.
+
+    Splits on newline boundaries where possible to keep sections readable.
+    Paces posts slightly to stay under Discord webhook rate limits.
+    """
+    if not webhook_url or webhook_url.strip() == "" or webhook_url.startswith("placeholder"):
+        logger.info("Discord webhook URL not provided or is placeholder, skipping Discord notification")
+        return
+
+    lines = text.split("\n")
+    parts = []
+    current_lines = []
+    current_len = 0
+
+    for line in lines:
+        # +1 accounts for the newline we'll reinsert
+        projected = current_len + len(line) + 1
+        if projected > chunk_size and current_lines:
+            parts.append("\n".join(current_lines))
+            current_lines = [line]
+            current_len = len(line) + 1
+        else:
+            current_lines.append(line)
+            current_len += len(line) + 1
+
+    if current_lines:
+        parts.append("\n".join(current_lines))
+
+    for i, part in enumerate(parts):
+        post_to_discord(webhook_url, part)
+        if i + 1 < len(parts):
+            time.sleep(0.45)

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 
 import requests
 from flask import Blueprint, jsonify, request
@@ -132,17 +133,48 @@ def _post_to_discord_cto(message: str) -> None:
         return
     if len(message) > 2000:
         message = message[:1997] + "..."
-    try:
-        resp = requests.post(webhook, json={"content": message}, timeout=20)
-        if resp.status_code != 204:
+    # Discord webhooks allow ~5 requests / 2s; retry briefly on 429 so chunked
+    # reviews are not silently truncated after the first message.
+    for attempt in range(4):
+        try:
+            resp = requests.post(webhook, json={"content": message}, timeout=20)
+            if resp.status_code == 204:
+                logger.info("CTO Discord post succeeded")
+                return
+            if resp.status_code == 429:
+                retry_after = 1.0
+                try:
+                    retry_after = float(resp.headers.get("Retry-After") or "1")
+                except ValueError:
+                    retry_after = 1.0
+                time.sleep(min(max(retry_after, 0.5), 5.0))
+                continue
             logger.warning("CTO Discord post failed: %s %s", resp.status_code, resp.text[:200])
-        else:
-            logger.info("CTO Discord post succeeded")
-    except Exception:
-        logger.warning("CTO Discord post failed", exc_info=True)
+            return
+        except Exception:
+            logger.warning("CTO Discord post failed", exc_info=True)
+            return
+    logger.warning("CTO Discord post failed after retries (rate limited)")
 
 
-def _post_to_discord_cto_chunks(message: str, *, chunk_size: int = 1900) -> None:
+def _discord_chunk_end(msg: str, start: int, chunk_size: int) -> int:
+    """Pick a chunk boundary that prefers paragraph / heading breaks over mid-line cuts."""
+    end = min(start + chunk_size, len(msg))
+    if end >= len(msg):
+        return end
+    para = msg.rfind("\n\n", start, end)
+    if para > start + 120:
+        return para + 2
+    heading = msg.rfind("\n### ", start, end)
+    if heading > start + 120:
+        return heading + 1
+    nl = msg.rfind("\n", start, end)
+    if nl > start + 120:
+        return nl + 1
+    return end
+
+
+def _post_to_discord_cto_chunks(message: str, *, chunk_size: int = 1800) -> None:
     """Post long content to CTO Discord in multiple messages. Discord limit 2000 chars; we use chunk_size margin."""
     webhook = (os.environ.get("DISCORD_WEBHOOK_URL_CTO") or "").strip()
     if not webhook or webhook.startswith("placeholder"):
@@ -154,12 +186,22 @@ def _post_to_discord_cto_chunks(message: str, *, chunk_size: int = 1900) -> None
         _post_to_discord_cto(msg)
         return
     start = 0
+    part = 0
     while start < len(msg):
-        end = min(start + chunk_size, len(msg))
-        nl = msg.rfind("\n", start, end)
-        if nl > start + 200:
-            end = nl
-        _post_to_discord_cto(msg[start:end].strip())
+        end = _discord_chunk_end(msg, start, chunk_size)
+        if end <= start:
+            end = min(start + chunk_size, len(msg))
+        chunk = msg[start:end].strip()
+        if chunk:
+            part += 1
+            # Label continuations so partial delivery is obvious in Discord.
+            prefix = f"_(continued {part})_\n" if part > 1 else ""
+            body = prefix + chunk
+            if len(body) > 2000:
+                body = body[:1997] + "..."
+            _post_to_discord_cto(body)
+            # Stay under Discord webhook rate limits between chunks.
+            time.sleep(0.45)
         start = end
 
 

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 
 import requests
 from flask import Blueprint, jsonify, request
@@ -26,6 +25,7 @@ from bigas.resources.cto.pr_review.github_client import (
     GitHubPRCommentError,
 )
 from bigas.resources.cto.pr_review.service import PRReviewError, PRReviewService
+from bigas.discord_webhook import post_long_to_discord, post_to_discord
 from bigas.resources.marketing.utils import sanitize_error_message
 
 cto_bp = Blueprint(
@@ -123,86 +123,30 @@ def _notify_autofix_loop_protection(
         logger.warning("Loop-protection Jira comment failed", exc_info=True)
 
 
+def _cto_discord_webhook() -> str:
+    webhook = (os.environ.get("DISCORD_WEBHOOK_URL_CTO") or "").strip()
+    if not webhook or webhook.startswith("placeholder"):
+        return ""
+    return webhook
+
+
 def _post_to_discord_cto(message: str) -> None:
     """Post to CTO Discord channel if DISCORD_WEBHOOK_URL_CTO is set (e.g. from Secret Manager).
     Callers must pass only sanitized messages (use sanitize_error_message for errors) to avoid leaking tokens.
     """
-    webhook = (os.environ.get("DISCORD_WEBHOOK_URL_CTO") or "").strip()
-    if not webhook or webhook.startswith("placeholder"):
+    webhook = _cto_discord_webhook()
+    if not webhook:
         logger.info("DISCORD_WEBHOOK_URL_CTO not set or placeholder, skipping Discord post")
         return
-    if len(message) > 2000:
-        message = message[:1997] + "..."
-    # Discord webhooks allow ~5 requests / 2s; retry briefly on 429 so chunked
-    # reviews are not silently truncated after the first message.
-    for attempt in range(4):
-        try:
-            resp = requests.post(webhook, json={"content": message}, timeout=20)
-            if resp.status_code == 204:
-                logger.info("CTO Discord post succeeded")
-                return
-            if resp.status_code == 429:
-                retry_after = 1.0
-                try:
-                    retry_after = float(resp.headers.get("Retry-After") or "1")
-                except ValueError:
-                    retry_after = 1.0
-                time.sleep(min(max(retry_after, 0.5), 5.0))
-                continue
-            logger.warning("CTO Discord post failed: %s %s", resp.status_code, resp.text[:200])
-            return
-        except Exception:
-            logger.warning("CTO Discord post failed", exc_info=True)
-            return
-    logger.warning("CTO Discord post failed after retries (rate limited)")
+    post_to_discord(webhook, message)
 
 
-def _discord_chunk_end(msg: str, start: int, chunk_size: int) -> int:
-    """Pick a chunk boundary that prefers paragraph / heading breaks over mid-line cuts."""
-    end = min(start + chunk_size, len(msg))
-    if end >= len(msg):
-        return end
-    para = msg.rfind("\n\n", start, end)
-    if para > start + 120:
-        return para + 2
-    heading = msg.rfind("\n### ", start, end)
-    if heading > start + 120:
-        return heading + 1
-    nl = msg.rfind("\n", start, end)
-    if nl > start + 120:
-        return nl + 1
-    return end
-
-
-def _post_to_discord_cto_chunks(message: str, *, chunk_size: int = 1800) -> None:
-    """Post long content to CTO Discord in multiple messages. Discord limit 2000 chars; we use chunk_size margin."""
-    webhook = (os.environ.get("DISCORD_WEBHOOK_URL_CTO") or "").strip()
-    if not webhook or webhook.startswith("placeholder"):
+def _post_to_discord_cto_chunks(message: str) -> None:
+    """Post long CTO content via the shared Discord long-message helper."""
+    webhook = _cto_discord_webhook()
+    if not webhook or not (message or "").strip():
         return
-    if not message:
-        return
-    msg = message.strip()
-    if len(msg) <= 2000:
-        _post_to_discord_cto(msg)
-        return
-    start = 0
-    part = 0
-    while start < len(msg):
-        end = _discord_chunk_end(msg, start, chunk_size)
-        if end <= start:
-            end = min(start + chunk_size, len(msg))
-        chunk = msg[start:end].strip()
-        if chunk:
-            part += 1
-            # Label continuations so partial delivery is obvious in Discord.
-            prefix = f"_(continued {part})_\n" if part > 1 else ""
-            body = prefix + chunk
-            if len(body) > 2000:
-                body = body[:1997] + "..."
-            _post_to_discord_cto(body)
-            # Stay under Discord webhook rate limits between chunks.
-            time.sleep(0.45)
-        start = end
+    post_long_to_discord(webhook, message.strip())
 
 
 @cto_bp.route("/review_and_comment_pr", methods=["POST"])

--- a/bigas/resources/marketing/endpoints.py
+++ b/bigas/resources/marketing/endpoints.py
@@ -6375,72 +6375,8 @@ def send_discord_message(message: str) -> bool:
     return post_to_discord(webhook_url, message)
 
 
-def post_to_discord(webhook_url, message: str) -> bool:
-    """
-    Post a single message to Discord, truncating hard at 2000 characters.
-    Returns True if the request succeeded (HTTP 204), False otherwise.
-
-    NOTE: For longer, multi-part messages use post_long_to_discord instead.
-    """
-    if (
-        not webhook_url
-        or webhook_url.strip() == ""
-        or webhook_url.strip().lower().startswith("placeholder")
-    ):
-        logger.info("Discord webhook URL not provided or is placeholder, skipping Discord notification")
-        return False
-
-    if len(message) > 2000:
-        message = message[:1997] + "..."
-    data = {"content": message}
-    try:
-        response = requests.post(
-            webhook_url,
-            json=data,
-            timeout=DISCORD_HTTP_TIMEOUT,
-        )
-        if response.status_code != 204:
-            logger.error(f"Failed to post to Discord: {response.status_code}, {response.text}")
-            return False
-        logger.info("Successfully posted to Discord")
-        return True
-    except Exception as e:
-        logger.error(f"Error posting to Discord: {e}")
-        return False
-
-
-def post_long_to_discord(webhook_url: str, text: str, chunk_size: int = 1900):
-    """
-    Post a long markdown-like text to Discord, splitting it into multiple
-    messages that respect Discord's 2000 character limit.
-
-    Splits on newline boundaries where possible to keep sections readable.
-    """
-    if not webhook_url or webhook_url.strip() == "" or webhook_url.startswith("placeholder"):
-        logger.info("Discord webhook URL not provided or is placeholder, skipping Discord notification")
-        return
-
-    lines = text.split("\n")
-    parts = []
-    current_lines = []
-    current_len = 0
-
-    for line in lines:
-        # +1 accounts for the newline we'll reinsert
-        projected = current_len + len(line) + 1
-        if projected > chunk_size and current_lines:
-            parts.append("\n".join(current_lines))
-            current_lines = [line]
-            current_len = len(line) + 1
-        else:
-            current_lines.append(line)
-            current_len += len(line) + 1
-
-    if current_lines:
-        parts.append("\n".join(current_lines))
-
-    for part in parts:
-        post_to_discord(webhook_url, part)
+# Backwards-compatible re-exports (canonical implementation: bigas.discord_webhook).
+from bigas.discord_webhook import post_long_to_discord, post_to_discord  # noqa: E402
 
 @marketing_bp.route('/openapi.json', methods=['GET'])
 def openapi_spec():


### PR DESCRIPTION
## Summary
- Retry Discord webhook posts on HTTP 429
- Pace chunked review posts and prefer paragraph/heading split points
- Label continuation chunks so partial delivery is visible

## Test plan
- [ ] Trigger a long CTO PR review and confirm Discord receives all `(continued N)` parts