### PR TITLE
Include Jira link types in Research/Design

### DIFF
--- a/bigas/resources/product/jira_automation/design.py
+++ b/bigas/resources/product/jira_automation/design.py
@@ -26,7 +26,7 @@ from bigas.resources.product.jira_automation.prompts import (
 )
 from bigas.resources.product.jira_automation.research import (
     _format_linked_issues,
-    _linked_issue_keys,
+    _linked_issue_entries,
 )
 
 logger = logging.getLogger(__name__)
@@ -82,8 +82,9 @@ class DesignPlanHandler:
         brief = extract_brief(description_plain) or description_plain or summary
         research = extract_section(description_plain, RESEARCH_HEADING)
 
-        linked_keys = _linked_issue_keys(fields)
-        linked_text = _format_linked_issues(self._jira, linked_keys)
+        linked_entries = _linked_issue_entries(fields)
+        linked_keys = [e["key"] for e in linked_entries]
+        linked_text = _format_linked_issues(self._jira, linked_keys, entries=linked_entries)
 
         try:
             raw_comments = self._jira.list_comments(issue_key, max_results=50)

--- a/bigas/resources/product/jira_automation/prompts.py
+++ b/bigas/resources/product/jira_automation/prompts.py
@@ -2,11 +2,12 @@
 
 RESEARCH_SYSTEM_PROMPT = """You are a senior product engineer helping refine a Jira issue.
 
-Your job: take a short human Brief plus context (linked issues, repo notes, web snippets) and produce a clear, detailed research write-up that another AI (and a human) can use in later design/implement phases.
+Your job: take a short human Brief plus context (linked issues with relation types such as blocks / relates to, repo notes, web snippets) and produce a clear, detailed research write-up that another AI (and a human) can use in later design/implement phases.
 
 Rules:
 - Preserve the intent of the human Brief; do not invent business requirements that contradict it.
 - Treat human follow-up comments as authoritative clarifications (especially answers to open questions).
+- Respect issue link types: e.g. "blocks" / "is blocked by" affect priority and sequencing; "relates to" is weaker context.
 - Prefer concrete, testable acceptance criteria.
 - Call out unknowns and open questions explicitly.
 - Suggest improvements (scope cuts, risks, alternatives) briefly.
@@ -37,7 +38,7 @@ Summary: {summary}
 ## Human follow-up comments
 {comments_text or "(none)"}
 
-## Linked issues
+## Linked issues (with relation type)
 {linked_issues_text or "(none)"}
 
 ## Codebase context
@@ -60,11 +61,12 @@ Write the research body with these sections:
 
 DESIGN_SYSTEM_PROMPT = """You are a senior software engineer writing an implementation plan for a Jira issue.
 
-Your job: turn the approved Brief + AI Research (plus repo context and human comments) into a concrete design and implementation plan that a Cursor cloud agent (and a human reviewer) can follow.
+Your job: turn the approved Brief + AI Research (plus repo context, linked issues with relation types, and human comments) into a concrete design and implementation plan that a Cursor cloud agent (and a human reviewer) can follow.
 
 Rules:
 - Stay within the Brief and Research; do not expand product scope.
 - Human follow-up comments override or clarify open questions from Research when they conflict.
+- Respect issue link types (blocks / is blocked by / relates to / parent) when ordering work and calling out dependencies.
 - Be specific about files/modules when the repo context supports it; otherwise mark unknowns.
 - Prefer incremental, testable steps over big-bang rewrites.
 - Include risks, edge cases, and a short test plan.
@@ -98,7 +100,7 @@ Summary: {summary}
 ## Human follow-up comments
 {comments_text or "(none)"}
 
-## Linked issues
+## Linked issues (with relation type)
 {linked_issues_text or "(none)"}
 
 ## Codebase context

--- a/bigas/resources/product/jira_automation/research.py
+++ b/bigas/resources/product/jira_automation/research.py
@@ -31,28 +31,72 @@ class ResearchHandlerError(RuntimeError):
     pass
 
 
-def _linked_issue_keys(fields: Dict[str, Any]) -> List[str]:
-    keys: List[str] = []
+def _linked_issue_entries(fields: Dict[str, Any]) -> List[Dict[str, str]]:
+    """
+    Collect linked issues with human-readable relation labels.
+
+    Jira issuelinks expose either outwardIssue or inwardIssue (the other end).
+    We keep type.outward / type.inward so prompts know blocks vs relates-to, etc.
+    """
+    entries: List[Dict[str, str]] = []
     seen = set()
     for link in fields.get("issuelinks") or []:
-        for side in ("outwardIssue", "inwardIssue"):
-            issue = link.get(side) or {}
-            key = (issue.get("key") or "").strip()
-            if key and key not in seen:
-                seen.add(key)
-                keys.append(key)
+        if not isinstance(link, dict):
+            continue
+        link_type = link.get("type") if isinstance(link.get("type"), dict) else {}
+        outward = link.get("outwardIssue") if isinstance(link.get("outwardIssue"), dict) else None
+        inward = link.get("inwardIssue") if isinstance(link.get("inwardIssue"), dict) else None
+        if outward and (outward.get("key") or "").strip():
+            key = (outward.get("key") or "").strip()
+            relation = (link_type.get("outward") or link_type.get("name") or "related").strip()
+            direction = "outward"
+        elif inward and (inward.get("key") or "").strip():
+            key = (inward.get("key") or "").strip()
+            relation = (link_type.get("inward") or link_type.get("name") or "related").strip()
+            direction = "inward"
+        else:
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append({"key": key, "relation": relation, "direction": direction})
+
     parent = fields.get("parent") or {}
     parent_key = (parent.get("key") or "").strip()
     if parent_key and parent_key not in seen:
-        keys.append(parent_key)
-    return keys
+        entries.append({"key": parent_key, "relation": "parent", "direction": "inward"})
+    return entries
 
 
-def _format_linked_issues(jira: JiraClient, keys: List[str]) -> str:
-    if not keys:
+def _linked_issue_keys(fields: Dict[str, Any]) -> List[str]:
+    return [e["key"] for e in _linked_issue_entries(fields)]
+
+
+def _format_linked_issues(
+    jira: JiraClient,
+    keys: List[str],
+    *,
+    entries: Optional[List[Dict[str, str]]] = None,
+) -> str:
+    """
+    Format linked issues for LLM prompts.
+
+    Prefer ``entries`` (includes relation type). ``keys`` kept for callers that
+    only have keys; relation then shows as ``linked``.
+    """
+    if entries is None:
+        entries = [{"key": k, "relation": "linked", "direction": "outward"} for k in keys]
+    if not entries:
         return "(none)"
+
     lines = []
-    for key in keys[:15]:
+    for entry in entries[:15]:
+        key = entry.get("key") or ""
+        if not key:
+            continue
+        relation = (entry.get("relation") or "linked").strip()
+        direction = (entry.get("direction") or "").strip()
+        arrow = "→" if direction == "outward" else "←" if direction == "inward" else "·"
         try:
             issue = jira.get_issue(
                 key,
@@ -63,9 +107,11 @@ def _format_linked_issues(jira: JiraClient, keys: List[str]) -> str:
             status = ((fields.get("status") or {}).get("name") or "").strip()
             itype = ((fields.get("issuetype") or {}).get("name") or "").strip()
             desc = adf_to_plain_text(fields.get("description"))[:800]
-            lines.append(f"- {key} [{itype}/{status}]: {summary}\n  {desc}")
+            lines.append(
+                f"- {key} [{relation} {arrow}] [{itype}/{status}]: {summary}\n  {desc}"
+            )
         except JiraError as e:
-            lines.append(f"- {key}: (unavailable: {e})")
+            lines.append(f"- {key} [{relation} {arrow}]: (unavailable: {e})")
     return "\n".join(lines)
 
 
@@ -114,8 +160,9 @@ class ResearchDescribeHandler:
         description_plain = adf_to_plain_text(fields.get("description"))
         brief = extract_brief(description_plain) or description_plain or summary
 
-        linked_keys = _linked_issue_keys(fields)
-        linked_text = _format_linked_issues(self._jira, linked_keys)
+        linked_entries = _linked_issue_entries(fields)
+        linked_keys = [e["key"] for e in linked_entries]
+        linked_text = _format_linked_issues(self._jira, linked_keys, entries=linked_entries)
 
         try:
             raw_comments = self._jira.list_comments(issue_key, max_results=50)

--- a/tests/test_jira_automation.py
+++ b/tests/test_jira_automation.py
@@ -157,6 +157,64 @@ def test_extract_jira_issue_key_from_pr_texts():
     assert extract_jira_issue_key("no key here") is None
 
 
+def test_linked_issue_entries_include_relation_type():
+    from bigas.resources.product.jira_automation.research import (
+        _format_linked_issues,
+        _linked_issue_entries,
+        _linked_issue_keys,
+    )
+
+    fields = {
+        "issuelinks": [
+            {
+                "type": {
+                    "name": "Blocks",
+                    "inward": "is blocked by",
+                    "outward": "blocks",
+                },
+                "outwardIssue": {"key": "VFA-10"},
+            },
+            {
+                "type": {
+                    "name": "Relates",
+                    "inward": "relates to",
+                    "outward": "relates to",
+                },
+                "inwardIssue": {"key": "VFA-8"},
+            },
+        ],
+        "parent": {"key": "VFA-1"},
+    }
+    entries = _linked_issue_entries(fields)
+    assert _linked_issue_keys(fields) == ["VFA-10", "VFA-8", "VFA-1"]
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["VFA-10"]["relation"] == "blocks"
+    assert by_key["VFA-10"]["direction"] == "outward"
+    assert by_key["VFA-8"]["relation"] == "relates to"
+    assert by_key["VFA-8"]["direction"] == "inward"
+    assert by_key["VFA-1"]["relation"] == "parent"
+
+    class FakeJira:
+        def get_issue(self, key, fields=None):
+            return {
+                "fields": {
+                    "summary": f"Summary {key}",
+                    "status": {"name": "To Do"},
+                    "issuetype": {"name": "Story"},
+                    "description": None,
+                }
+            }
+
+    text = _format_linked_issues(
+        FakeJira(),  # type: ignore[arg-type]
+        [],
+        entries=entries,
+    )
+    assert "VFA-10 [blocks →]" in text
+    assert "VFA-8 [relates to ←]" in text
+    assert "VFA-1 [parent ←]" in text
+
+
 def test_build_implement_prompt_forbids_confirmation():
     from bigas.resources.product.jira_automation.implement import build_implement_prompt
 


### PR DESCRIPTION
## Summary
- Linked issues in Research/Design prompts now include relation labels (\`blocks →\`, \`is blocked by ←\`, \`relates to\`, \`parent\`).
- System prompts tell the model to respect link types for sequencing.

## Test plan
- [x] unit tests for entries + formatting
- [ ] deploy