### PR TITLE
Respect project Firebase helpers in PR review

### DIFF
--- a/bigas/resources/cto/autofix/service.py
+++ b/bigas/resources/cto/autofix/service.py
@@ -45,6 +45,7 @@ Pull request: {pr_url}
 6. Do not merge the PR, do not force-push, do not rewrite history, and do not open a new PR.
 7. If after inspecting the code there is nothing safe to fix, make no commits and explain why.
 8. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — apply the fixes and push commits immediately. Do not stop after a proposal.
+9. If the review claims a helper/import is wrong (e.g. deleteField vs FieldValue.delete) but the repo already provides that helper via a local wrapper imported in the same file, treat the finding as already resolved — do not churn the code just to silence the review.
 """
 
 

--- a/bigas/resources/cto/pr_review/prompts.py
+++ b/bigas/resources/cto/pr_review/prompts.py
@@ -25,6 +25,23 @@ End with one short overall verdict sentence. If there are no blockers and no
 important issues, include the phrase "ready to merge".
 """.strip()
 
+_PROJECT_HELPER_RULES = """
+Project helpers / imports (avoid false blockers):
+- Prefer the repository's existing wrappers and helpers when the diff uses them.
+  Example: many backends export `deleteField()`, `serverTimestamp()`, etc. from a
+  local `firebase` module that already wraps `admin.firestore.FieldValue.delete()`.
+- Do NOT flag `deleteField()` (or similar helpers) as missing/wrong solely because
+  the call site does not import `FieldValue` from `firebase-admin`, if the same
+  file imports the helper from a local module (e.g. `from '../firebase'`).
+- Only report an import/API blocker when the symbol is truly undefined in the
+  shown diff (no import and no local definition), or when the wrong SDK API is
+  used without a project wrapper.
+- When re-checking a previous finding about helpers/imports, look at imports in
+  the same file in the diff. If the helper is imported from the project wrapper,
+  treat the finding as resolved — do not repeat it.
+""".strip()
+
+
 PR_REVIEW_SYSTEM_PROMPT = f"""You are a senior engineer performing a pull request review.
 Your role is to catch real issues early with specific, actionable feedback.
 
@@ -34,6 +51,8 @@ Guidelines:
 - Do not invent problems. Prefer fewer true issues over padded nits.
 - Return only the review text—no meta-commentary, no "Here is my review" wrapper.
 - Start directly with the review content.
+
+{_PROJECT_HELPER_RULES}
 
 {_REVIEW_FORMAT}
 """
@@ -58,6 +77,8 @@ Guidelines:
   8. UI edge cases: empty states, negative values, sorting stability
 - Return only the review text—no meta-commentary wrapper.
 
+{_PROJECT_HELPER_RULES}
+
 {_REVIEW_FORMAT}
 """
 
@@ -73,6 +94,11 @@ Guidelines:
 - If previous Blockers/Important are resolved and no new blockers/important remain,
   say the PR is ready to merge.
 - Be specific with file paths. Return only the review text.
+- If a previous blocker was about a missing/wrong helper (e.g. deleteField vs
+  FieldValue.delete) and the file imports a project wrapper that provides that
+  helper, mark it resolved — do not keep re-reporting it.
+
+{_PROJECT_HELPER_RULES}
 
 {_REVIEW_FORMAT}
 """

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -99,6 +99,18 @@ def test_autofix_prompt_forbids_confirmation():
     assert "apply the fixes and push commits immediately" in prompt
     assert "Also fix Minor items" in prompt
     assert "Fix all Blockers and Important" in prompt
+    assert "already resolved" in prompt or "local wrapper" in prompt
+
+
+def test_pr_review_prompts_respect_project_helpers():
+    from bigas.resources.cto.pr_review.prompts import (
+        PR_REVIEW_INITIAL_SYSTEM_PROMPT,
+        PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT,
+    )
+
+    for text in (PR_REVIEW_INITIAL_SYSTEM_PROMPT, PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT):
+        assert "deleteField()" in text
+        assert "Project helpers" in text
 
 
 def test_autofix_looks_like_confirmation_stop():


### PR DESCRIPTION
## Summary
- PR review prompts: do not flag \`deleteField()\` / similar helpers when imported from a local firebase wrapper.
- Post-autofix: treat such findings as resolved when the wrapper import is present.
- Autofix prompt: do not churn code just to silence a false helper/import finding.

## Test plan
- [x] unit tests for prompt text
- [ ] deploy; re-run review on PR #15 (or next synchronize)