### PR TITLE
Autofix cooldown + clearer loop-protection text

### DIFF
--- a/bigas/resources/cto/autofix/heuristics.py
+++ b/bigas/resources/cto/autofix/heuristics.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 AUTOFIX_COMMIT_MARKER = "[bigas-autofix]"
 DEFAULT_AUTOFIX_MAX_ITERATIONS = 5
+DEFAULT_AUTOFIX_COOLDOWN_SECONDS = 600
 
 
 def autofix_max_iterations() -> int:
@@ -20,6 +21,30 @@ def autofix_max_iterations() -> int:
     except ValueError:
         return DEFAULT_AUTOFIX_MAX_ITERATIONS
 
+
+def autofix_cooldown_seconds() -> int:
+    """
+    Skip launching a new autofix if the latest head commit is already an autofix
+    and younger than this many seconds (env BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS).
+    """
+    import os
+
+    raw = (os.environ.get("BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS") or "").strip()
+    if not raw:
+        return DEFAULT_AUTOFIX_COOLDOWN_SECONDS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return DEFAULT_AUTOFIX_COOLDOWN_SECONDS
+
+
+def format_loop_protection_message(*, autofix_count: int, max_iterations: int) -> str:
+    """Human-readable loop-protection copy for Discord / Jira / API reason."""
+    return (
+        f"Exceeded autofix limit of {max_iterations} "
+        f"(found {autofix_count} `[bigas-autofix]` commits on this PR). "
+        f"Remaining review comments need manual handling."
+    )
 
 _CLEAN = re.compile(
     r"(?i)\b(looks good( to me)?|lgtm|safe to merge|ready to merge|"

--- a/bigas/resources/cto/autofix/service.py
+++ b/bigas/resources/cto/autofix/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from bigas.resources.cto.autofix.cursor_client import (
@@ -11,7 +12,9 @@ from bigas.resources.cto.autofix.cursor_client import (
 )
 from bigas.resources.cto.autofix.heuristics import (
     AUTOFIX_COMMIT_MARKER,
+    autofix_cooldown_seconds,
     autofix_max_iterations,
+    format_loop_protection_message,
     review_needs_autofix,
 )
 from bigas.resources.cto.pr_review.github_client import (
@@ -66,6 +69,19 @@ def autofix_looks_like_confirmation_stop(result_text: str) -> bool:
     return any(n in text for n in needles)
 
 
+def _age_seconds_since(iso_ts: Optional[str]) -> Optional[float]:
+    if not iso_ts:
+        return None
+    raw = iso_ts.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return max(0.0, (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).total_seconds())
+
+
 class AutofixService:
     def __init__(
         self,
@@ -104,12 +120,13 @@ class AutofixService:
         pr_url = f"https://github.com/{repo}/pull/{pr_number}"
         repo_url = f"https://github.com/{repo}"
         max_iters = autofix_max_iterations()
+        cooldown = autofix_cooldown_seconds()
 
         gh = GitHubPRCommentClient(token=self._github_token)
 
         try:
-            head_sha, head_message = gh.get_pr_head_commit(
-                owner=owner, repo=repo_name, pr_number=pr_number
+            head_sha, head_message, committed_at = gh.get_pr_head_commit_meta(
+                owner, repo_name, pr_number
             )
             autofix_count = gh.count_autofix_commits(
                 owner, repo_name, pr_number, marker=AUTOFIX_COMMIT_MARKER
@@ -121,15 +138,39 @@ class AutofixService:
             return {
                 "skipped": True,
                 "loop_protection": True,
-                "reason": (
-                    f"loop protection: {autofix_count}/{max_iters} autofix rounds "
-                    f"already on this PR — remaining review comments need manual handling"
+                "reason": format_loop_protection_message(
+                    autofix_count=autofix_count, max_iterations=max_iters
                 ),
                 "pr_url": pr_url,
                 "autofix_count": autofix_count,
                 "max_iterations": max_iters,
                 "head_sha": head_sha,
             }
+
+        # Prevent overlapping launches while a previous autofix commit is still fresh.
+        if (
+            not force
+            and cooldown > 0
+            and AUTOFIX_COMMIT_MARKER in (head_message or "")
+        ):
+            age = _age_seconds_since(committed_at)
+            if age is not None and age < cooldown:
+                wait_left = int(cooldown - age)
+                return {
+                    "skipped": True,
+                    "cooldown": True,
+                    "reason": (
+                        f"autofix cooldown: latest commit is already `[bigas-autofix]` "
+                        f"({int(age)}s ago). Wait ~{wait_left}s for the previous agent "
+                        f"to finish before launching another round."
+                    ),
+                    "pr_url": pr_url,
+                    "autofix_count": autofix_count,
+                    "max_iterations": max_iters,
+                    "cooldown_seconds": cooldown,
+                    "head_age_seconds": int(age),
+                    "head_sha": head_sha,
+                }
 
         body = (review_body or "").strip()
         if not body:

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -11,6 +11,7 @@ from flask import Blueprint, jsonify, request
 
 from bigas.resources.cto.autofix.heuristics import (
     autofix_max_iterations,
+    format_loop_protection_message,
     latest_commit_is_autofix,
     review_is_ready_to_merge,
 )
@@ -69,10 +70,12 @@ def _notify_autofix_loop_protection(
     max_iterations: int,
     github_token: str = "",
 ) -> None:
+    detail = format_loop_protection_message(
+        autofix_count=autofix_count, max_iterations=max_iterations
+    )
     msg = (
         f"**CTO autofix stopped (loop protection)**\n"
-        f"Reached {autofix_count}/{max_iterations} automatic fix rounds without a clean review.\n"
-        f"Remaining review comments need **manual handling**.\n"
+        f"{detail}\n"
         f"PR: {pr_url}"
     )
     _post_to_discord_cto(msg)
@@ -114,9 +117,8 @@ def _notify_autofix_loop_protection(
         jira = JiraClient(JiraConfig.from_env())
         jira.add_comment(
             issue_key,
-            f"{BIGAS_COMMENT_MARKER} Autofix loop protection "
-            f"({autofix_count}/{max_iterations}).\n"
-            f"Automatic fixes stopped; remaining PR review comments need manual handling.\n"
+            f"{BIGAS_COMMENT_MARKER} Autofix loop protection.\n"
+            f"{detail}\n"
             f"Left in current status.\nPR: {pr_url}",
         )
     except Exception:
@@ -404,6 +406,12 @@ def autofix_pr():
             _post_to_discord_cto(
                 f"**CTO autofix skipped**\n"
                 f"Review does not need autofix ({sanitize_error_message(reason)}).\n"
+                f"PR: {pr_url}"
+            )
+        elif result.get("cooldown"):
+            _post_to_discord_cto(
+                f"**CTO autofix cooldown**\n"
+                f"{sanitize_error_message(reason)}\n"
                 f"PR: {pr_url}"
             )
         else:

--- a/bigas/resources/cto/pr_review/github_client.py
+++ b/bigas/resources/cto/pr_review/github_client.py
@@ -5,7 +5,7 @@ Uses a hidden HTML comment marker so we update the same comment on repeated runs
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import requests
 
@@ -144,6 +144,22 @@ class GitHubPRCommentClient:
         """
         Return (head_sha, commit_message) for the PR head.
         """
+        sha, message, _committed_at = self.get_pr_head_commit_meta(
+            owner, repo, pr_number
+        )
+        return sha, message
+
+    def get_pr_head_commit_meta(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+    ) -> tuple[str, str, Optional[str]]:
+        """
+        Return (head_sha, commit_message, committed_at_iso) for the PR head.
+
+        ``committed_at_iso`` is the committer date in ISO-8601 when available.
+        """
         pr_api = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
         resp = requests.get(pr_api, headers=self._headers, timeout=30)
         if resp.status_code == 404:
@@ -168,17 +184,21 @@ class GitHubPRCommentClient:
         commit_api = f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}"
         cresp = requests.get(commit_api, headers=self._headers, timeout=30)
         if cresp.status_code >= 400:
-            # Fall back to empty message; loop-guard then only matches on force.
             logger.warning(
                 "Failed to fetch commit message for %s: %s",
                 sha[:8],
                 cresp.status_code,
             )
-            return sha, ""
+            return sha, "", None
         cdata = cresp.json() if cresp.text else {}
-        message = ((cdata.get("commit") or {}).get("message") or "").strip()
-        return sha, message
-
+        commit = cdata.get("commit") or {}
+        message = (commit.get("message") or "").strip()
+        committed_at = (
+            ((commit.get("committer") or {}).get("date") or "").strip()
+            or ((commit.get("author") or {}).get("date") or "").strip()
+            or None
+        )
+        return sha, message, committed_at
     def get_pr_diff(self, owner: str, repo: str, pr_number: int) -> str:
         """Fetch the pull request diff text via the GitHub API."""
         pr_api = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -33,6 +33,7 @@ Optional:
 
 - `BIGAS_CTO_AUTOFIX_MODEL` (Cursor model id). Omit to use Cursor’s default.
 - `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default `5`) — max `[bigas-autofix]` commits per PR before loop protection.
+- `BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS` (default `600`) — skip launching another autofix while the PR head is still a fresh `[bigas-autofix]` commit (reduces overlapping agents).
 
 ## Repo config
 

--- a/env.example
+++ b/env.example
@@ -98,6 +98,7 @@ CURSOR_API_KEY=your_cursor_api_key_here
 # Optional: Cursor model id for autofix (omit for Cursor default).
 # BIGAS_CTO_AUTOFIX_MODEL=composer-2.5
 # BIGAS_CTO_AUTOFIX_MAX_ITERATIONS=5
+# BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS=600
 # Optional: model for CTO PR review. Override via BIGAS_CTO_PR_REVIEW_MODEL or request body llm_model.
 # BIGAS_CTO_PR_REVIEW_MODEL=gemini-pro-latest
 # Optional: max diff size in characters (default 150000). Truncation note is prepended if exceeded.

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -88,6 +88,24 @@ def test_autofix_max_iterations_env(monkeypatch):
     assert autofix_max_iterations() == 1
 
 
+def test_format_loop_protection_message_is_clear():
+    from bigas.resources.cto.autofix.heuristics import format_loop_protection_message
+
+    msg = format_loop_protection_message(autofix_count=9, max_iterations=5)
+    assert "limit of 5" in msg
+    assert "found 9" in msg
+    assert "manual handling" in msg
+
+
+def test_autofix_cooldown_seconds_env(monkeypatch):
+    from bigas.resources.cto.autofix.heuristics import autofix_cooldown_seconds
+
+    monkeypatch.delenv("BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS", raising=False)
+    assert autofix_cooldown_seconds() == 600
+    monkeypatch.setenv("BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS", "120")
+    assert autofix_cooldown_seconds() == 120
+
+
 def test_autofix_prompt_forbids_confirmation():
     prompt = _build_prompt(
         repo="mckort/bigas",


### PR DESCRIPTION
## Summary
- Discord/Jira loop protection: \`Exceeded limit of 5 (found 9 ...)\` instead of confusing \`9/5\`.
- Cooldown (default 600s): do not launch another autofix while head is still a fresh \`[bigas-autofix]\` commit (cuts overlapping agents).

## Test plan
- [x] unit tests
- [ ] deploy