### PR TITLE
Add marketing workstream prompts via Jira label

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Say you write a card with just a **Brief** — a couple of sentences on what you
 
 Every AI step lands in a column with **"(manual)"** in the name — nothing merges or ships without a human dragging a card or approving a PR.
 
+**Prompt workstream:** by default Bigas uses **product** Research/Design/Implement prompts. Add the Jira label `marketing` on website/SEO/content issues to switch to marketing-oriented prompts (audience, copy, SEO, site files in the repo).
+
 Under the hood, each column is wired the same way: a **Jira Automation** rule (not the admin "Webhook listener") does a **Send web request** to `jira_status_automation` whenever an issue enters that status. One rule per AI status, same URL and headers, different trigger:
 
 ```bash

--- a/bigas/resources/product/jira_automation/design.py
+++ b/bigas/resources/product/jira_automation/design.py
@@ -21,8 +21,8 @@ from bigas.resources.product.jira_automation.description import (
 )
 from bigas.resources.product.jira_automation.github_context import GitHubRepoContext
 from bigas.resources.product.jira_automation.prompts import (
-    DESIGN_SYSTEM_PROMPT,
-    build_design_user_prompt,
+    design_prompts_for,
+    resolve_workstream,
 )
 from bigas.resources.product.jira_automation.research import (
     _format_linked_issues,
@@ -95,12 +95,14 @@ class DesignPlanHandler:
 
         hints = [summary]
         labels = fields.get("labels") or []
+        workstream = resolve_workstream(labels)
+        system_prompt, build_user_prompt = design_prompts_for(workstream)
         hints.extend(str(l) for l in labels[:5])
         if research:
             hints.append(research[:80])
         repo_context = self._github.fetch_context(repo, query_hints=hints)
 
-        user_prompt = build_design_user_prompt(
+        user_prompt = build_user_prompt(
             issue_key=issue_key,
             summary=summary,
             brief=brief,
@@ -112,7 +114,7 @@ class DesignPlanHandler:
         try:
             plan_body = self._llm.complete(
                 messages=[
-                    {"role": "system", "content": DESIGN_SYSTEM_PROMPT},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
                 max_tokens=4000,
@@ -142,7 +144,8 @@ class DesignPlanHandler:
                 issue_key,
                 to_status_name=approval_status,
                 comment=(
-                    f"{BIGAS_COMMENT_MARKER} Design/plan complete. "
+                    f"{BIGAS_COMMENT_MARKER} Design/plan complete "
+                    f"(workstream={workstream}). "
                     f"Moved to {approval_status} for human review. "
                     f"(model={self._model})"
                 ),
@@ -157,6 +160,7 @@ class DesignPlanHandler:
             "summary": summary,
             "model": self._model,
             "repo": repo,
+            "workstream": workstream,
             "linked_issues": linked_keys,
             "moved_to": approval_status,
             "plan_chars": len(plan_body),

--- a/bigas/resources/product/jira_automation/implement.py
+++ b/bigas/resources/product/jira_automation/implement.py
@@ -31,6 +31,11 @@ from bigas.resources.product.jira_automation.description import (
     extract_brief,
     extract_section,
 )
+from bigas.resources.product.jira_automation.prompts import (
+    build_implement_prompt_product,
+    implement_prompt_for,
+    resolve_workstream,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,45 +77,8 @@ def _monitor_interval_seconds() -> int:
         return 30
 
 
-def build_implement_prompt(
-    *,
-    issue_key: str,
-    summary: str,
-    brief: str,
-    research: str,
-    plan: str,
-    comments_text: str,
-    repo: str,
-) -> str:
-    return f"""You are implementing a Jira issue in repository {repo}.
-
-Issue: {issue_key}
-Summary: {summary}
-
-## Human Brief
-{brief or "(empty)"}
-
-## AI Research
-{research or "(empty)"}
-
-## AI Plan
-{plan or "(empty)"}
-
-## Human follow-up comments
-{comments_text or "(none)"}
-
-## Instructions
-1. Implement the issue according to the Brief, Research, Plan, and human comments.
-2. Prefer the AI Plan for technical approach; treat human comments as clarifications that override open questions.
-3. Keep scope tight — do not refactor unrelated code.
-4. Add/update tests when reasonable.
-5. Open a pull request when done (autoCreatePR is enabled).
-6. PR title MUST start with `{issue_key}:` followed by a short summary.
-7. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
-8. Do not merge the PR.
-9. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
-"""
-
+# Backward-compatible alias (product workstream).
+build_implement_prompt = build_implement_prompt_product
 
 def lookup_pr_url_for_branch(*, repo: str, branch_name: str) -> str:
     """Return open PR URL for branch if found via GitHub API."""
@@ -250,6 +218,8 @@ class ImplementHandler:
         brief = extract_brief(description_plain) or description_plain or summary
         research = extract_section(description_plain, RESEARCH_HEADING)
         plan = extract_section(description_plain, PLAN_HEADING)
+        workstream = resolve_workstream(fields.get("labels") or [])
+        build_prompt = implement_prompt_for(workstream)
 
         try:
             raw_comments = self._jira.list_comments(issue_key, max_results=50)
@@ -263,7 +233,7 @@ class ImplementHandler:
                 "No AI Plan / AI Research sections found — run Research and Design first."
             )
 
-        prompt = build_implement_prompt(
+        prompt = build_prompt(
             issue_key=issue_key,
             summary=summary,
             brief=brief,
@@ -291,7 +261,8 @@ class ImplementHandler:
         run_id = launched.get("run_id") or ""
 
         comment = (
-            f"{BIGAS_COMMENT_MARKER} Implementation started via Cursor cloud agent.\n"
+            f"{BIGAS_COMMENT_MARKER} Implementation started via Cursor cloud agent "
+            f"(workstream={workstream}).\n"
             f"Repo: `{repo}` (base `{base_branch}`)\n"
             f"Agent: {agent_url or agent_id}\n"
             f"agent_id={agent_id} run_id={run_id}\n"
@@ -340,6 +311,7 @@ class ImplementHandler:
             "issue_key": issue_key,
             "summary": summary,
             "repo": repo,
+            "workstream": workstream,
             "base_branch": base_branch,
             "agent_id": agent_id,
             "agent_url": agent_url,

--- a/bigas/resources/product/jira_automation/prompts.py
+++ b/bigas/resources/product/jira_automation/prompts.py
@@ -1,4 +1,39 @@
-"""Prompts for Research and describe (AI)."""
+"""Prompts for Jira AI Research / Design (product default + marketing label)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Optional, Tuple
+
+WORKSTREAM_PRODUCT = "product"
+WORKSTREAM_MARKETING = "marketing"
+MARKETING_LABEL = "marketing"
+
+
+def normalize_labels(labels: Optional[Iterable[Any]]) -> tuple[str, ...]:
+    out: list[str] = []
+    for raw in labels or []:
+        s = str(raw or "").strip()
+        if s:
+            out.append(s)
+    return tuple(out)
+
+
+def resolve_workstream(labels: Optional[Iterable[Any]] = None) -> str:
+    """
+    Pick prompt workstream from Jira labels.
+
+    Default is product (current prompts). Label ``marketing`` (case-insensitive)
+    switches to marketing/website prompts.
+    """
+    for label in normalize_labels(labels):
+        if label.lower() == MARKETING_LABEL:
+            return WORKSTREAM_MARKETING
+    return WORKSTREAM_PRODUCT
+
+
+# ---------------------------------------------------------------------------
+# Product (default) — unchanged behavior
+# ---------------------------------------------------------------------------
 
 RESEARCH_SYSTEM_PROMPT = """You are a senior product engineer helping refine a Jira issue.
 
@@ -115,3 +150,229 @@ Write the plan body with these sections:
 ### Rollout / flags / migrations
 ### Risks & open questions
 """
+
+
+# ---------------------------------------------------------------------------
+# Marketing / website (label: marketing)
+# ---------------------------------------------------------------------------
+
+RESEARCH_SYSTEM_PROMPT_MARKETING = """You are a senior marketing + web content specialist helping refine a Jira issue for a code-backed website or marketing site.
+
+Your job: take a short human Brief plus context (linked issues, repo notes, web snippets) and produce a clear research write-up that another AI (and a human) can use to change site content, SEO, blog posts, landing pages, or marketing copy in the repository.
+
+Rules:
+- Preserve the intent of the human Brief; do not invent brand claims, pricing, or legal statements that contradict it.
+- Treat human follow-up comments as authoritative clarifications.
+- Respect issue link types for sequencing (blocks / is blocked by / relates to).
+- Focus on audience, message, SEO, content structure, and where content lives in the codebase (MDX/Markdown, CMS content folders, page components, metadata).
+- Prefer concrete, testable acceptance criteria (visible copy, meta tags, URLs, internal links).
+- Call out unknowns (missing draft copy, target keywords, locale) explicitly.
+- Do NOT include a "## Brief" or "## AI Research" heading — return only the research body markdown.
+- Use markdown: short sections, bullets where helpful.
+- If evidence is weak, say so; do not invent pages, routes, or files that were not in the context.
+"""
+
+
+def build_research_user_prompt_marketing(
+    *,
+    issue_key: str,
+    summary: str,
+    brief: str,
+    linked_issues_text: str,
+    repo_context: str,
+    web_context: str,
+    comments_text: str = "(none)",
+) -> str:
+    return f"""Expand and refine this marketing/website Jira issue for downstream design and implementation in the site repo.
+
+Issue: {issue_key}
+Summary: {summary}
+
+## Human Brief
+{brief or "(empty)"}
+
+## Human follow-up comments
+{comments_text or "(none)"}
+
+## Linked issues (with relation type)
+{linked_issues_text or "(none)"}
+
+## Codebase context (site structure / content locations)
+{repo_context or "(none)"}
+
+## Web snippets
+{web_context or "(none)"}
+
+Write the research body with these sections:
+### Problem / context (audience & funnel)
+### Goals
+### Non-goals
+### Message / content outline
+### SEO & metadata notes (title, description, headings, internal links)
+### Proposed approach (research-level)
+### Acceptance criteria
+### Suggested improvements
+### Open questions / risks
+### Relevant pages / content files / components
+"""
+
+
+DESIGN_SYSTEM_PROMPT_MARKETING = """You are a senior web/marketing engineer writing an implementation plan for a Jira issue on a code-backed marketing website.
+
+Your job: turn the approved Brief + AI Research into a concrete plan a Cursor cloud agent can follow to update content, SEO, blog posts, or page copy in the repository (not a greenfield product feature unless the Brief requires it).
+
+Rules:
+- Stay within the Brief and Research; do not expand campaign scope.
+- Human follow-up comments override open questions when they conflict.
+- Prefer editing existing content patterns in the repo (content collections, MDX, page components, shared layout/SEO helpers).
+- Be specific about files/routes when repo context supports it; otherwise mark unknowns.
+- Include SEO checklist items (meta, headings, slug/URL, sitemap/OG if relevant in-repo).
+- Include a short verification plan (what to click/view locally or in preview).
+- Do NOT include "## Brief", "## AI Research", or "## AI Plan" headings — return only the plan body markdown.
+- Use markdown with short sections and bullets.
+- Do not invent CMS APIs, routes, or files that are not evidenced in the context.
+"""
+
+
+def build_design_user_prompt_marketing(
+    *,
+    issue_key: str,
+    summary: str,
+    brief: str,
+    research: str,
+    linked_issues_text: str,
+    repo_context: str,
+    comments_text: str = "(none)",
+) -> str:
+    return f"""Write a website/marketing implementation plan for this Jira issue.
+
+Issue: {issue_key}
+Summary: {summary}
+
+## Human Brief
+{brief or "(empty)"}
+
+## AI Research (approved context)
+{research or "(empty)"}
+
+## Human follow-up comments
+{comments_text or "(none)"}
+
+## Linked issues (with relation type)
+{linked_issues_text or "(none)"}
+
+## Codebase context
+{repo_context or "(none)"}
+
+Write the plan body with these sections:
+### Content / UX approach
+### Pages, routes, and files likely touched
+### Copy / media / SEO details to implement
+### Step-by-step implementation plan
+### Verification plan (preview checklist)
+### Rollout notes (publish, redirects, sitemap)
+### Risks & open questions
+"""
+
+
+def build_implement_prompt_product(
+    *,
+    issue_key: str,
+    summary: str,
+    brief: str,
+    research: str,
+    plan: str,
+    comments_text: str,
+    repo: str,
+) -> str:
+    return f"""You are implementing a Jira issue in repository {repo}.
+
+Issue: {issue_key}
+Summary: {summary}
+
+## Human Brief
+{brief or "(empty)"}
+
+## AI Research
+{research or "(empty)"}
+
+## AI Plan
+{plan or "(empty)"}
+
+## Human follow-up comments
+{comments_text or "(none)"}
+
+## Instructions
+1. Implement the issue according to the Brief, Research, Plan, and human comments.
+2. Prefer the AI Plan for technical approach; treat human comments as clarifications that override open questions.
+3. Keep scope tight — do not refactor unrelated code.
+4. Add/update tests when reasonable.
+5. Open a pull request when done (autoCreatePR is enabled).
+6. PR title MUST start with `{issue_key}:` followed by a short summary.
+7. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
+8. Do not merge the PR.
+9. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
+"""
+
+
+def build_implement_prompt_marketing(
+    *,
+    issue_key: str,
+    summary: str,
+    brief: str,
+    research: str,
+    plan: str,
+    comments_text: str,
+    repo: str,
+) -> str:
+    return f"""You are implementing a marketing/website Jira issue in repository {repo}.
+
+Issue: {issue_key}
+Summary: {summary}
+
+## Human Brief
+{brief or "(empty)"}
+
+## AI Research
+{research or "(empty)"}
+
+## AI Plan
+{plan or "(empty)"}
+
+## Human follow-up comments
+{comments_text or "(none)"}
+
+## Instructions
+1. Implement content/SEO/page changes according to the Brief, Research, Plan, and human comments.
+2. Prefer existing site patterns (content folders, MDX/Markdown, page components, shared SEO/metadata helpers).
+3. Keep scope tight — do not redesign unrelated pages or refactor the whole site.
+4. Match tone and structure of existing content in the repo when writing copy unless the Brief specifies otherwise.
+5. Include sensible SEO basics when relevant (title/description/headings/slug) using the project's existing conventions.
+6. Open a pull request when done (autoCreatePR is enabled).
+7. PR title MUST start with `{issue_key}:` followed by a short summary.
+8. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
+9. Do not merge the PR.
+10. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
+"""
+
+
+def research_prompts_for(
+    workstream: str,
+) -> Tuple[str, Callable[..., str]]:
+    if workstream == WORKSTREAM_MARKETING:
+        return RESEARCH_SYSTEM_PROMPT_MARKETING, build_research_user_prompt_marketing
+    return RESEARCH_SYSTEM_PROMPT, build_research_user_prompt
+
+
+def design_prompts_for(
+    workstream: str,
+) -> Tuple[str, Callable[..., str]]:
+    if workstream == WORKSTREAM_MARKETING:
+        return DESIGN_SYSTEM_PROMPT_MARKETING, build_design_user_prompt_marketing
+    return DESIGN_SYSTEM_PROMPT, build_design_user_prompt
+
+
+def implement_prompt_for(workstream: str) -> Callable[..., str]:
+    if workstream == WORKSTREAM_MARKETING:
+        return build_implement_prompt_marketing
+    return build_implement_prompt_product

--- a/bigas/resources/product/jira_automation/research.py
+++ b/bigas/resources/product/jira_automation/research.py
@@ -19,8 +19,8 @@ from bigas.resources.product.jira_automation.description import (
 )
 from bigas.resources.product.jira_automation.github_context import GitHubRepoContext
 from bigas.resources.product.jira_automation.prompts import (
-    RESEARCH_SYSTEM_PROMPT,
-    build_research_user_prompt,
+    research_prompts_for,
+    resolve_workstream,
 )
 from bigas.resources.product.jira_automation.web_research import fetch_web_snippets
 
@@ -173,13 +173,15 @@ class ResearchDescribeHandler:
 
         hints = [summary]
         labels = fields.get("labels") or []
+        workstream = resolve_workstream(labels)
+        system_prompt, build_user_prompt = research_prompts_for(workstream)
         hints.extend(str(l) for l in labels[:5])
         repo_context = self._github.fetch_context(repo, query_hints=hints)
 
         web_query = f"{summary} {brief[:120]}".strip()
         web_context = fetch_web_snippets(web_query)
 
-        user_prompt = build_research_user_prompt(
+        user_prompt = build_user_prompt(
             issue_key=issue_key,
             summary=summary,
             brief=brief,
@@ -191,7 +193,7 @@ class ResearchDescribeHandler:
         try:
             research_body = self._llm.complete(
                 messages=[
-                    {"role": "system", "content": RESEARCH_SYSTEM_PROMPT},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
                 max_tokens=3500,
@@ -222,7 +224,8 @@ class ResearchDescribeHandler:
                 issue_key,
                 to_status_name=approval_status,
                 comment=(
-                    f"{BIGAS_COMMENT_MARKER} Research complete. "
+                    f"{BIGAS_COMMENT_MARKER} Research complete "
+                    f"(workstream={workstream}). "
                     f"Moved to {approval_status} for human review. "
                     f"(model={self._model})"
                 ),
@@ -237,6 +240,7 @@ class ResearchDescribeHandler:
             "summary": summary,
             "model": self._model,
             "repo": repo,
+            "workstream": workstream,
             "linked_issues": linked_keys,
             "moved_to": approval_status,
             "research_chars": len(research_body),

--- a/docs/jira-automation.md
+++ b/docs/jira-automation.md
@@ -61,3 +61,12 @@ Headers: `Content-Type: application/json`, `X-Bigas-Webhook-Secret`, and `X-Biga
 ```
 
 Human comments are included in Research / Design / Implement prompts. `[bigas-jira-ai]` system comments are ignored.
+
+## Workstream prompts (label)
+
+| Label | Workstream | Prompts |
+|---|---|---|
+| *(none / other)* | **product** (default) | Current product engineer Research / Design / Implement prompts |
+| `marketing` (case-insensitive) | **marketing** | Website/content/SEO-oriented prompts (copy, pages, metadata, site patterns in-repo) |
+
+Add the Jira label `marketing` on SEO/blog/landing-page issues. Leave unlabeled for normal product work.

--- a/tests/test_jira_automation.py
+++ b/tests/test_jira_automation.py
@@ -233,6 +233,40 @@ def test_build_implement_prompt_forbids_confirmation():
     assert "Jira: VFA-14" in prompt
 
 
+def test_resolve_workstream_defaults_to_product():
+    from bigas.resources.product.jira_automation.prompts import (
+        WORKSTREAM_MARKETING,
+        WORKSTREAM_PRODUCT,
+        implement_prompt_for,
+        research_prompts_for,
+        resolve_workstream,
+    )
+
+    assert resolve_workstream(None) == WORKSTREAM_PRODUCT
+    assert resolve_workstream([]) == WORKSTREAM_PRODUCT
+    assert resolve_workstream(["bug", "backend"]) == WORKSTREAM_PRODUCT
+    assert resolve_workstream(["Marketing"]) == WORKSTREAM_MARKETING
+    assert resolve_workstream(["seo", "marketing"]) == WORKSTREAM_MARKETING
+
+    product_system, _ = research_prompts_for(WORKSTREAM_PRODUCT)
+    marketing_system, _ = research_prompts_for(WORKSTREAM_MARKETING)
+    assert "product engineer" in product_system
+    assert "marketing + web content" in marketing_system
+
+    marketing_impl = implement_prompt_for(WORKSTREAM_MARKETING)(
+        issue_key="WAYW-1",
+        summary="SEO",
+        brief="fix titles",
+        research="r",
+        plan="p",
+        comments_text="(none)",
+        repo="mckort/roadpal",
+    )
+    assert "marketing/website" in marketing_impl
+    assert "SEO basics" in marketing_impl
+    assert "Do NOT ask for confirmation" in marketing_impl
+
+
 def test_extract_pr_and_branch_from_cursor_payload():
     from bigas.resources.cto.autofix.cursor_client import extract_pr_and_branch
 


### PR DESCRIPTION
## Summary
- Route Research/Design/Implement to marketing/website prompts when the Jira issue has label `marketing`
- Keep current product prompts as the default for unlabeled issues and other labels (e.g. `customer-request`)

## Test plan
- [ ] Issue without `marketing` label uses product prompts (unchanged)
- [ ] Issue with `marketing` label shows workstream=marketing in Bigas Jira comment
- [ ] Marketing Research/Design sections reflect SEO/content-oriented structure