### PR TITLE
Fix CTO review Discord failure context and curl -f

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,13 +48,13 @@ jobs:
           set -euo pipefail
           # Prefer the GitHub API diff for this PR number. Local `git diff base...HEAD`
           # can be empty if the PR was merged into the base branch before this job ran.
-          HTTP_CODE=$(curl -sS -w "%{http_code}" -o diff.txt \
+          # -f fails on HTTP 4xx/5xx so error JSON is not treated as a valid diff.
+          if ! curl -fsS -o diff.txt \
             -H "Accept: application/vnd.github.diff" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Failed to fetch PR diff from GitHub API (HTTP $HTTP_CODE)"
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"; then
+            echo "::error::Failed to fetch PR diff from GitHub API"
             head -c 500 diff.txt || true
             exit 1
           fi

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 def _resolve_pr_diff_text(
     *,
-    diff: object,
+    diff: str | None,
     owner: str,
     repo_name: str,
     pr_number: int,
@@ -202,9 +202,16 @@ def review_and_comment_pr():
     instructions = (data.get("instructions") or "").strip() or None
     github_token = (data.get("github_token") or "").strip() or os.environ.get("GITHUB_TOKEN") or ""
     llm_model = (data.get("llm_model") or "").strip() or None
+    repo_display = repo or "?"
+    pr_display = pr_number if pr_number is not None else "?"
 
     def _fail(reason: str, status: int, error: str | None = None):
-        _post_to_discord_cto(f"**CTO PR review done**\nNo comment posted.\nReason: {reason}")
+        _post_to_discord_cto(
+            "**CTO PR review done**\n"
+            "No comment posted.\n"
+            f"PR: https://github.com/{repo_display}/pull/{pr_display}\n"
+            f"Reason: {reason}"
+        )
         return jsonify({"error": error or reason}), status
 
     if not repo:
@@ -219,6 +226,7 @@ def review_and_comment_pr():
         return _fail("pr_number must be an integer.", 400)
     if pr_number < 1:
         return _fail("pr_number must be positive.", 400, "pr_number must be a positive integer")
+    pr_display = pr_number
     if diff is not None and not isinstance(diff, str):
         return _fail("diff must be a string.", 400)
     if not github_token:

--- a/docs/cto-pr-review.md
+++ b/docs/cto-pr-review.md
@@ -56,7 +56,7 @@ Optional autofix (Cursor cloud agent): set repository variable `BIGAS_AUTO_FIX=t
     GH_TOKEN: ${{ secrets.GH_PAT_FOR_BIGAS || github.token }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
   run: |
-    curl -sS -o diff.txt \
+    curl -fsS -o diff.txt \
       -H "Accept: application/vnd.github.diff" \
       -H "Authorization: Bearer $GH_TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
## Summary
- Discord failure messages from \`review_and_comment_pr\` now include the PR URL
- Workflow/docs use \`curl -fsS\` so GitHub API errors are not ingested as diffs
- Tighten \`_resolve_pr_diff_text\` type hint to \`str | None\`

## Test plan
- [x] unit tests for diff resolution
- [ ] Confirm a deliberate bad review request Discord message includes the PR link