### PR TITLE
Use curl --fail-with-body for PR diff fetch

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -48,8 +48,8 @@ jobs:
           set -euo pipefail
           # Prefer the GitHub API diff for this PR number. Local `git diff base...HEAD`
           # can be empty if the PR was merged into the base branch before this job ran.
-          # -f fails on HTTP 4xx/5xx so error JSON is not treated as a valid diff.
-          if ! curl -fsS -o diff.txt \
+          # --fail-with-body fails on HTTP 4xx/5xx but still writes the error body for debugging.
+          if ! curl --fail-with-body -sS -o diff.txt \
             -H "Accept: application/vnd.github.diff" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -226,7 +226,6 @@ def review_and_comment_pr():
         return _fail("pr_number must be an integer.", 400)
     if pr_number < 1:
         return _fail("pr_number must be positive.", 400, "pr_number must be a positive integer")
-    pr_display = pr_number
     if diff is not None and not isinstance(diff, str):
         return _fail("diff must be a string.", 400)
     if not github_token:

--- a/docs/cto-pr-review.md
+++ b/docs/cto-pr-review.md
@@ -56,7 +56,7 @@ Optional autofix (Cursor cloud agent): set repository variable `BIGAS_AUTO_FIX=t
     GH_TOKEN: ${{ secrets.GH_PAT_FOR_BIGAS || github.token }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
   run: |
-    curl -fsS -o diff.txt \
+    curl --fail-with-body -sS -o diff.txt \
       -H "Accept: application/vnd.github.diff" \
       -H "Authorization: Bearer $GH_TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
## Summary
- Switch workflow/docs from \`curl -f\` to \`curl --fail-with-body\` so API error JSON remains available in logs
- Drop redundant \`pr_display\` reassignment

## Test plan
- [ ] On a forced API failure, Actions log shows error body from \`diff.txt\`