### PR TITLE
Harden Bigas PR review diff UTF-8 reading

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           python3 -c "
           import json, os
-          with open('diff.txt') as f:
+          with open('diff.txt', encoding='utf-8', errors='replace') as f:
               diff = f.read()
           payload = {
               'repo': os.environ['GITHUB_REPOSITORY'],

--- a/docs/cto-pr-review.md
+++ b/docs/cto-pr-review.md
@@ -76,7 +76,7 @@ Optional autofix (Cursor cloud agent): set repository variable `BIGAS_AUTO_FIX=t
   run: |
     python3 -c "
     import json, os
-    with open('diff.txt') as f:
+    with open('diff.txt', encoding='utf-8', errors='replace') as f:
         diff = f.read()
     payload = {
         'repo': os.environ['GITHUB_REPOSITORY'],


### PR DESCRIPTION
## Summary
- Read `diff.txt` with `encoding=utf-8, errors=replace` in the CTO PR review workflow and docs template.
- Prevents workflow crashes if a diff ever contains non-UTF8 bytes before Discord notify.

## Test plan
- [ ] Open/sync a PR in a consumer repo with a binary fixture and confirm Bigas review completes (HTTP 200)