### PR TITLE
Require mobile-responsive UI in Jira AI and PR review prompts

### DIFF
--- a/bigas/resources/cto/pr_review/prompts.py
+++ b/bigas/resources/cto/pr_review/prompts.py
@@ -49,6 +49,7 @@ Guidelines:
 - Focus on logic, correctness, security, maintainability, and clear naming.
 - Be specific: reference file paths and code snippets where relevant.
 - Do not invent problems. Prefer fewer true issues over padded nits.
+- For UI diffs: flag layouts that break on small mobile screens (~320–390px) or lack responsive behavior.
 - Return only the review text—no meta-commentary, no "Here is my review" wrapper.
 - Start directly with the review content.
 
@@ -74,7 +75,7 @@ Guidelines:
   5. Storage/file lifecycle: upload failure cleanup, delete on accept/discard, TTL orphans
   6. Transactions / duplicate detection / limits that can silently truncate
   7. Error handling that hides failures from users
-  8. UI edge cases: empty states, negative values, sorting stability
+  8. UI edge cases: empty states, negative values, sorting stability, and mobile/responsive layout on small screens (~320–390px)
 - Return only the review text—no meta-commentary wrapper.
 
 {_PROJECT_HELPER_RULES}

--- a/bigas/resources/product/jira_automation/prompts.py
+++ b/bigas/resources/product/jira_automation/prompts.py
@@ -107,6 +107,7 @@ Rules:
 - Include risks, edge cases, and a short test plan.
 - Call out README impact: whether README (or equivalent docs) should be updated for install/config/run/usage changes.
 - Call out in-app support/help impact: whether end-user help articles (in-app support pages) should be added or updated when the change affects how users use the product.
+- For any UI change: require responsive design that works on a small mobile screen (~320–390px width); call out layout, overflow, and touch targets in the plan and test plan. Skip when there is no UI.
 - Do NOT include "## Brief", "## AI Research", or "## AI Plan" headings — return only the plan body markdown.
 - Use markdown with short sections and bullets.
 - Do not invent APIs, tables, or files that are not evidenced in the context.
@@ -150,6 +151,7 @@ Write the plan body with these sections:
 ### Step-by-step implementation plan
 ### README / docs impact
 ### In-app support / help impact
+### Mobile / responsive considerations (if UI)
 ### Test plan
 ### Rollout / flags / migrations
 ### Risks & open questions
@@ -233,6 +235,7 @@ Rules:
 - Include SEO checklist items (meta, headings, slug/URL, sitemap/OG if relevant in-repo).
 - Include a short verification plan (what to click/view locally or in preview).
 - Call out README/docs impact when routes, content workflows, or contributor setup change.
+- For any UI/page change: require responsive design that works on a small mobile screen (~320–390px width); include mobile checks in the verification plan. Skip when there is no UI.
 - Do NOT include "## Brief", "## AI Research", or "## AI Plan" headings — return only the plan body markdown.
 - Use markdown with short sections and bullets.
 - Do not invent CMS APIs, routes, or files that are not evidenced in the context.
@@ -275,6 +278,7 @@ Write the plan body with these sections:
 ### Copy / media / SEO details to implement
 ### Step-by-step implementation plan
 ### README / docs impact
+### Mobile / responsive considerations (if UI)
 ### Verification plan (preview checklist)
 ### Rollout notes (publish, redirects, sitemap)
 ### Risks & open questions
@@ -315,11 +319,12 @@ Summary: {summary}
 4. Add/update tests when reasonable.
 5. Update the repository README when the change affects how people install, configure, run, or understand the project. Skip README edits for purely internal refactors with no user-facing or ops impact.
 6. Update in-app support/help content (end-user help articles / support pages) when the change affects what users see or how they use the product. Skip when there is no user-facing behavior change, or when the repo has no in-app help.
-7. Open a pull request when done (autoCreatePR is enabled).
-8. PR title MUST start with `{issue_key}:` followed by a short summary.
-9. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
-10. Do not merge the PR.
-11. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
+7. All UI changes must also work on a small mobile screen (responsive design). Verify layout, spacing, and interaction at ~320–390px width; avoid fixed widths that break on mobile unless the Brief says otherwise. Skip when there is no UI.
+8. Open a pull request when done (autoCreatePR is enabled).
+9. PR title MUST start with `{issue_key}:` followed by a short summary.
+10. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
+11. Do not merge the PR.
+12. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
 """
 
 
@@ -357,11 +362,12 @@ Summary: {summary}
 4. Match tone and structure of existing content in the repo when writing copy unless the Brief specifies otherwise.
 5. Include sensible SEO basics when relevant (title/description/headings/slug) using the project's existing conventions.
 6. Update the repository README (or equivalent site docs) when the change affects how content, routes, SEO setup, or contributor workflows are documented. Skip when nothing user- or ops-facing changed.
-7. Open a pull request when done (autoCreatePR is enabled).
-8. PR title MUST start with `{issue_key}:` followed by a short summary.
-9. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
-10. Do not merge the PR.
-11. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
+7. All UI/page changes must also work on a small mobile screen (responsive design). Verify layout, spacing, and interaction at ~320–390px width; avoid fixed widths that break on mobile unless the Brief says otherwise. Skip when there is no UI.
+8. Open a pull request when done (autoCreatePR is enabled).
+9. PR title MUST start with `{issue_key}:` followed by a short summary.
+10. PR body MUST include a line exactly: `Jira: {issue_key}` and a short summary of what changed.
+11. Do not merge the PR.
+12. Do NOT ask for confirmation, approval, or whether to proceed. This is an unattended cloud agent — implement immediately and open the PR. Do not stop after a proposal.
 """
 
 

--- a/tests/test_autofix_heuristics.py
+++ b/tests/test_autofix_heuristics.py
@@ -124,12 +124,15 @@ def test_pr_review_prompts_respect_project_helpers():
     from bigas.resources.cto.pr_review.prompts import (
         PR_REVIEW_INITIAL_SYSTEM_PROMPT,
         PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT,
+        PR_REVIEW_SYSTEM_PROMPT,
     )
 
     for text in (PR_REVIEW_INITIAL_SYSTEM_PROMPT, PR_REVIEW_POST_AUTOFIX_SYSTEM_PROMPT):
         assert "deleteField()" in text
         assert "Project helpers" in text
 
+    assert "mobile/responsive" in PR_REVIEW_INITIAL_SYSTEM_PROMPT
+    assert "small mobile screens" in PR_REVIEW_SYSTEM_PROMPT
 
 def test_autofix_looks_like_confirmation_stop():
     assert autofix_looks_like_confirmation_stop(

--- a/tests/test_jira_automation.py
+++ b/tests/test_jira_automation.py
@@ -231,6 +231,8 @@ def test_build_implement_prompt_forbids_confirmation():
     assert "implement immediately" in prompt
     assert "Update the repository README" in prompt
     assert "Update in-app support/help content" in prompt
+    assert "small mobile screen" in prompt
+    assert "responsive design" in prompt
     assert "VFA-14:" in prompt
     assert "Jira: VFA-14" in prompt
 
@@ -253,9 +255,12 @@ def test_design_prompts_include_readme_impact():
     )
     assert "### README / docs impact" in product_plan
     assert "### In-app support / help impact" in product_plan
+    assert "### Mobile / responsive considerations (if UI)" in product_plan
 
     product_system, _ = design_prompts_for(WORKSTREAM_PRODUCT)
     assert "in-app support/help impact" in product_system
+    assert "responsive design" in product_system
+    assert "small mobile screen" in product_system
 
     _, build_marketing = design_prompts_for(WORKSTREAM_MARKETING)
     marketing_plan = build_marketing(
@@ -268,6 +273,11 @@ def test_design_prompts_include_readme_impact():
     )
     assert "### README / docs impact" in marketing_plan
     assert "### In-app support / help impact" not in marketing_plan
+    assert "### Mobile / responsive considerations (if UI)" in marketing_plan
+
+    marketing_system, _ = design_prompts_for(WORKSTREAM_MARKETING)
+    assert "responsive design" in marketing_system
+    assert "small mobile screen" in marketing_system
 
 
 def test_resolve_workstream_defaults_to_product():
@@ -302,6 +312,8 @@ def test_resolve_workstream_defaults_to_product():
     assert "marketing/website" in marketing_impl
     assert "SEO basics" in marketing_impl
     assert "Update the repository README" in marketing_impl
+    assert "small mobile screen" in marketing_impl
+    assert "responsive design" in marketing_impl
     assert "Do NOT ask for confirmation" in marketing_impl
 
 


### PR DESCRIPTION
## Summary
- Add responsive/mobile (~320–390px) requirements to Design and Implement prompts (product + marketing).
- Extend PR review guidelines/checklist to flag UI that breaks on small screens.
- Cover the new prompt wording in unit tests.

## Test plan
- [x] `pytest` for implement/design prompt tests and PR review prompt assertions
- [ ] Spot-check a UI Jira card through Design → Implement and confirm mobile notes appear
- [ ] Spot-check a UI PR review comment for mobile/responsive findings when relevant