### PR TITLE
Fix autofix cooldown hang with wait/retry and PR notice

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -110,6 +110,7 @@ jobs:
           BIGAS_API_KEY: ${{ secrets.BIGAS_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MAX_AUTOFIX_ROUNDS: "5"
+          MAX_COOLDOWN_WAITS: "3"
         run: |
           python3 <<'PY'
           import json, os, time, urllib.error, urllib.request
@@ -119,6 +120,7 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           pr_number = int(os.environ["PR_NUMBER"])
           max_rounds = int(os.environ.get("MAX_AUTOFIX_ROUNDS") or "5")
+          max_cooldown_waits = int(os.environ.get("MAX_COOLDOWN_WAITS") or "3")
 
           def call(path, body_obj, timeout=180):
               data = json.dumps(body_obj).encode()
@@ -181,7 +183,19 @@ jobs:
                   raise SystemExit(f"autofix_followup finalize failed: HTTP {code}")
               return final
 
-          for round_i in range(1, max_rounds + 1):
+          def cooldown_wait_seconds(data):
+              try:
+                  cooldown_s = int(data.get("cooldown_seconds") or 600)
+                  age_s = int(data.get("head_age_seconds") or 0)
+                  # Buffer so the next autofix_pr is past the server cooldown window.
+                  return max(30, cooldown_s - age_s + 15)
+              except (TypeError, ValueError):
+                  return 120
+
+          round_i = 0
+          cooldown_waits = 0
+          while round_i < max_rounds:
+              round_i += 1
               print(f"=== autofix round attempt {round_i}/{max_rounds} ===")
               code, data = call(
                   "autofix_pr",
@@ -195,6 +209,25 @@ jobs:
               if data.get("loop_protection"):
                   print("Loop protection reached; stopping.")
                   break
+
+              if data.get("cooldown"):
+                  if cooldown_waits >= max_cooldown_waits:
+                      print(
+                          "Too many cooldown waits in this run; stopping. "
+                          "Re-run the workflow after the cooldown window."
+                      )
+                      break
+                  wait_s = cooldown_wait_seconds(data)
+                  cooldown_waits += 1
+                  print(
+                      f"Autofix cooldown ({cooldown_waits}/{max_cooldown_waits}): "
+                      f"sleeping {wait_s}s then retrying same round "
+                      f"(reason={data.get('reason') or 'cooldown'})."
+                  )
+                  # Do not consume an autofix round for a cooldown skip.
+                  round_i -= 1
+                  time.sleep(wait_s)
+                  continue
 
               if data.get("skipped") or not data.get("launched"):
                   print(

--- a/bigas/resources/cto/endpoints.py
+++ b/bigas/resources/cto/endpoints.py
@@ -21,6 +21,7 @@ from bigas.resources.cto.autofix.service import (
     autofix_looks_like_confirmation_stop,
 )
 from bigas.resources.cto.pr_review.github_client import (
+    BIGAS_AUTOFIX_COOLDOWN_MARKER,
     BIGAS_REVIEW_MARKER,
     GitHubPRCommentClient,
     GitHubPRCommentError,
@@ -450,11 +451,47 @@ def autofix_pr():
                 f"PR: {pr_url}"
             )
         elif result.get("cooldown"):
+            reason = result.get("reason") or "cooldown"
+            wait_left = None
+            try:
+                cooldown_s = int(result.get("cooldown_seconds") or 0)
+                age_s = int(result.get("head_age_seconds") or 0)
+                if cooldown_s > 0:
+                    wait_left = max(0, cooldown_s - age_s)
+            except (TypeError, ValueError):
+                wait_left = None
+            mins = max(1, int((wait_left + 59) // 60)) if wait_left is not None else None
+            wait_txt = f"~{mins} min" if mins is not None else "a few minutes"
             _post_to_discord_cto(
                 f"**CTO autofix cooldown**\n"
                 f"{sanitize_error_message(reason)}\n"
                 f"PR: {pr_url}"
             )
+            # Visible on the PR so cooldown does not look like a silent hang.
+            gh_token = github_token or (os.environ.get("GITHUB_TOKEN") or "").strip()
+            if gh_token:
+                try:
+                    owner, repo_name = repo.split("/", 1)
+                    body = (
+                        "### Autofix paused (cooldown)\n\n"
+                        f"Latest head commit is already `[bigas-autofix]`. "
+                        f"Waiting **{wait_txt}** before launching another Cursor agent "
+                        "so agents do not overlap.\n\n"
+                        "The Actions autofix loop will retry automatically after the wait. "
+                        "You can also re-run **Bigas PR review** manually."
+                    )
+                    GitHubPRCommentClient(token=gh_token).post_or_update_pr_comment(
+                        owner=owner,
+                        repo=repo_name,
+                        pr_number=int(pr_number),
+                        body=body,
+                        marker=BIGAS_AUTOFIX_COOLDOWN_MARKER,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to post autofix cooldown PR comment",
+                        exc_info=True,
+                    )
         else:
             _post_to_discord_cto(
                 f"**CTO autofix skipped**\n"

--- a/bigas/resources/cto/pr_review/github_client.py
+++ b/bigas/resources/cto/pr_review/github_client.py
@@ -12,6 +12,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 BIGAS_REVIEW_MARKER = "<!-- bigas-ai-review-marker -->"
+BIGAS_AUTOFIX_COOLDOWN_MARKER = "<!-- bigas-autofix-cooldown-marker -->"
 
 
 class GitHubPRCommentError(RuntimeError):

--- a/docs/cto-autofix.md
+++ b/docs/cto-autofix.md
@@ -12,6 +12,7 @@ PR opened/push
       → autofix_pr
           → skip if review is LGTM / nits-only
           → skip with loop protection if PR already has ≥5 [bigas-autofix] commits
+          → if cooldown (fresh [bigas-autofix] head): Discord + PR notice, wait, retry
           → else launch Cursor cloud agent (workOnCurrentBranch)
       → poll autofix_followup until agent terminal
           → Discord: autofix completed / failed / without commits
@@ -33,7 +34,7 @@ Optional:
 
 - `BIGAS_CTO_AUTOFIX_MODEL` (Cursor model id). Omit to use Cursor’s default.
 - `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default `5`) — max `[bigas-autofix]` commits per PR before loop protection.
-- `BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS` (default `600`) — skip launching another autofix while the PR head is still a fresh `[bigas-autofix]` commit (reduces overlapping agents).
+- `BIGAS_CTO_AUTOFIX_COOLDOWN_SECONDS` (default `600`) — skip launching another autofix while the PR head is still a fresh `[bigas-autofix]` commit (reduces overlapping agents). The Actions loop **waits and retries** (up to 3 cooldown waits per run) instead of stopping. Bigas also posts/updates a visible PR comment (`<!-- bigas-autofix-cooldown-marker -->`) so cooldown is not mistaken for a hang.
 
 ## Repo config
 
@@ -91,5 +92,6 @@ The autofix prompt instructs the agent **not** to ask for confirmation and to pu
 - Skip soft-only language (`consider`, `TODO`, `optional`) unless Blockers/Important are present
 - When autofix *does* run (Blockers/Important present), the agent also fixes Minor items from the same review
 - Stop after `BIGAS_CTO_AUTOFIX_MAX_ITERATIONS` (default 5) commits containing `[bigas-autofix]`
+- Cooldown when head is a fresh `[bigas-autofix]` commit: Actions waits/retries; Bigas posts a PR cooldown notice
 - Agent prompt requires that marker in any commits it creates
 - Re-review after autofix uses a verification prompt and the previous Bigas comment, so it should not invent a fresh set of nits each round


### PR DESCRIPTION
## Summary
- Autofix Actions loop waits and retries when Bigas returns `cooldown` (up to 3 waits), instead of treating it as a terminal skip.
- Bigas posts/updates a visible PR comment on cooldown so the pause is obvious on the PR.
- Docs updated to describe the new behavior.

## Test plan
- [ ] Open/push a PR that triggers autofix, then push another `[bigas-autofix]` head and confirm the workflow sleeps/retries instead of exiting
- [ ] Confirm a cooldown PR comment appears (`Autofix paused (cooldown)`)
- [ ] Confirm Discord still receives the cooldown message
- [ ] Confirm non-cooldown skips (LGTM / nits) still stop the loop immediately